### PR TITLE
Add parts for binary names

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+3.36_01 - 2017-05-15
+
+    * Merge cperl improvements
+
 3.36 - 2017-05-14
 
     * Support Perl 5.26.* which no longer has '.' in @INC
@@ -43,17 +47,16 @@
     * Fix compiler warnings
       (Thanks to Dave M.)
 
-3.32_02 - 2014-04-14
+3.32_02 - 2016-04-14
 
-    * cperl added support for 5.16 binary names
-    * support @INC without . (-Dfortify_inc)
-    * See https://github.com/rurban/Devel-PPPort/tree/516gvhv
+    * Support silencing via make -s
+    * Support -Dfortify_inc, no . in @INC
 
 3.32_01 - 2015-03-31
 
     * Add HvNAMELEN, HvNAMEUTF8, HvENAME, HvENAMELEN, HvENAMEUTF8
       and gv_fetchpvn, gv_fetchmethod_flags, gv_init_pv, gv_init_pvn,
-      gv_init_sv (Reini Urban)
+      gv_init_sv (Reini Urban)    
 
 3.32 - 2015-09-30
 

--- a/Changes
+++ b/Changes
@@ -2,6 +2,21 @@
 
     * Support Perl 5.26.* which no longer has '.' in @INC
 
+3.35_03 - Sun May 14 2017 cperl-5.27.0
+
+    * Fix for . in @INC
+    * fix strict hashpairs
+
+3.35_02 - Sun Nov 20 2016 cperl-5.26.0
+
+    * Fix -Wc11-compat warning
+
+3.35_01 - Thu Oct 13 2016 cperl-5.24.1
+
+    * Merge cperl improvements
+    * make -s support
+    * fix for non-gcc 3.33_02
+
 3.35 - 2016-06-17
 
     * Fix compilation in bleadperl by removing a bad test.
@@ -27,6 +42,18 @@
       (Thanks to leont)
     * Fix compiler warnings
       (Thanks to Dave M.)
+
+3.32_02 - 2014-04-14
+
+    * cperl added support for 5.16 binary names
+    * support @INC without . (-Dfortify_inc)
+    * See https://github.com/rurban/Devel-PPPort/tree/516gvhv
+
+3.32_01 - 2015-03-31
+
+    * Add HvNAMELEN, HvNAMEUTF8, HvENAME, HvENAMELEN, HvENAMEUTF8
+      and gv_fetchpvn, gv_fetchmethod_flags, gv_init_pv, gv_init_pvn,
+      gv_init_sv (Reini Urban)
 
 3.32 - 2015-09-30
 

--- a/HACKERS
+++ b/HACKERS
@@ -193,7 +193,7 @@ section.
 
 =item *
 
-The code required to add to PPPort.xs for testing the implementation.
+The code required to add to F<PPPort.xs> for testing the implementation.
 This code goes into the C<=xshead>, C<=xsinit>, C<=xsmisc>, C<=xsboot>
 and C<=xsubs> section. Have a look at the template at the bottom
 of F<PPPort_xs.PL> to see where the code ends up.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -116,16 +116,16 @@ purge_all: realclean
 	@$(RM_F) PPPort.pm t/*.t
 
 regen_pm:
-	$(PERL) -I$(INST_ARCHLIB) -I$(INST_LIB) -I$(PERL_ARCHLIB) -I$(PERL_LIB) PPPort_pm.PL
+	$(PERL) -I. -I$(INST_ARCHLIB) -I$(INST_LIB) -I$(PERL_ARCHLIB) -I$(PERL_LIB) PPPort_pm.PL
 
 regen_xs:
-	$(PERL) -I$(INST_ARCHLIB) -I$(INST_LIB) -I$(PERL_ARCHLIB) -I$(PERL_LIB) PPPort_xs.PL
+	$(PERL) -I. -I$(INST_ARCHLIB) -I$(INST_LIB) -I$(PERL_ARCHLIB) -I$(PERL_LIB) PPPort_xs.PL
 
 regen_tests:
-	$(PERL) -I$(INST_ARCHLIB) -I$(INST_LIB) -I$(PERL_ARCHLIB) -I$(PERL_LIB) mktests.PL
+	$(PERL) -I. -I$(INST_ARCHLIB) -I$(INST_LIB) -I$(PERL_ARCHLIB) -I$(PERL_LIB) mktests.PL
 
 regen_h:
-	$(PERL) -I$(INST_ARCHLIB) -I$(INST_LIB) -I$(PERL_ARCHLIB) -I$(PERL_LIB) ppport_h.PL
+	$(PERL) -I. -I$(INST_ARCHLIB) -I$(INST_LIB) -I$(PERL_ARCHLIB) -I$(PERL_LIB) ppport_h.PL
 
 regen: regen_pm regen_xs regen_tests regen_h
 

--- a/PPPort_pm.PL
+++ b/PPPort_pm.PL
@@ -132,7 +132,8 @@ sub include
 {
   my($file, $opt) = @_;
 
-  print "including $file\n";
+  print "including $file\n" unless defined $ENV{MAKEFLAGS}
+        and $ENV{MAKEFLAGS} =~ /\b(s|silent|quiet)\b/;
 
   my $data = parse_partspec("$INCLUDE/$file");
 
@@ -539,7 +540,7 @@ package Devel::PPPort;
 use strict;
 use vars qw($VERSION $data);
 
-$VERSION = '3.36';
+$VERSION = '3.36_01';
 
 sub _init_data
 {

--- a/PPPort_xs.PL
+++ b/PPPort_xs.PL
@@ -44,7 +44,10 @@ for $file (all_files_in_dir('parts/inc')) {
   my $msg = 0;
   for $sec (keys %SECTION) {
     if (exists $spec->{$sec}) {
-      $msg++ or print "adding XS code from $file\n";
+      unless (defined $ENV{MAKEFLAGS}
+              and $ENV{MAKEFLAGS} =~ /\b(s|silent|quiet)\b/) {
+        $msg++ or print "adding XS code from $file\n";
+      }
       if (exists $SECTION{$sec}{header}) {
         my $header = $SECTION{$sec}{header};
         $header =~ s/__FILE__/$file/g;
@@ -66,6 +69,7 @@ for $sec (keys %SECTION) {
   $data =~ s/^__\U$sec\E__$/$code/m;
 }
 
+# backcompat
 open FH, ">RealPPPort.xs" or die "RealPPPort.xs: $!\n";
 print FH $data;
 close FH;

--- a/parts/apidoc.fnc
+++ b/parts/apidoc.fnc
@@ -13,69 +13,107 @@
 : source code, but are not contained in F<embed.fnc>.
 :
 
-AmUx|Perl_keyword_plugin_t|PL_keyword_plugin
-AmU|Perl_check_t *|PL_check
-AmU|yy_parser *|PL_parser
-AmU||G_ARRAY
-AmU||G_DISCARD
-AmU||G_EVAL
-AmU||G_NOARGS
-AmU||G_SCALAR
-AmU||G_VOID
-AmU||HEf_SVKEY
-AmU||MARK
-AmU||Nullav
-AmU||Nullch
-AmU||Nullcv
-AmU||Nullhv
-AmU||Nullsv
-AmU||ORIGMARK
-AmU||SP
-AmU||SVt_INVLIST
-AmU||SVt_IV
-AmU||SVt_NULL
-AmU||SVt_NV
-AmU||SVt_PV
-AmU||SVt_PVAV
-AmU||SVt_PVCV
-AmU||SVt_PVFM
-AmU||SVt_PVGV
-AmU||SVt_PVHV
-AmU||SVt_PVIO
-AmU||SVt_PVIV
-AmU||SVt_PVLV
-AmU||SVt_PVMG
-AmU||SVt_PVNV
-AmU||SVt_REGEXP
-AmU||UNDERBAR
-AmU||XCPT_CATCH
-AmU||XCPT_TRY_END
-AmU||XCPT_TRY_START
-AmU||XS
-AmU||XS_EXTERNAL
-AmU||XS_INTERNAL
-AmU||XS_VERSION
-AmU||newXSproto|char* name|XSUBADDR_t f|char* filename|const char *proto
-AmU||svtype
-Ama|SV*|newSVpvs_flags|const char* s|U32 flags
-Ama|SV*|newSVpvs_share|const char* s
-Ama|SV*|newSVpvs|const char* s
 Ama|char*|savepvs|const char* s
 Ama|char*|savesharedpvs|const char* s
-Amn|(whatever)|RETVAL
-Amn|(whatever)|THIS
+Ama|SV*|newSVpvs|const char* s
+Ama|SV*|newSVpvs_flags|const char* s|U32 flags
+Ama|SV*|newSVpvs_share|const char* s
+Am|AV*|GvAV|GV* gv
+Am|bool|isALPHA|char ch
+Am|bool|isALPHANUMERIC|char ch
+Am|bool|isASCII|char ch
+Am|bool|isBLANK|char ch
+Am|bool|isCNTRL|char ch
+Am|bool|isDIGIT|char ch
+Am|bool|isGRAPH|char ch
+Am|bool|isIDCONT|char ch
+Am|bool|isIDFIRST|char ch
+Am|bool|isLOWER|char ch
+Am|bool|isOCTAL|char ch
+Am|bool|isPRINT|char ch
+Am|bool|isPSXSPC|char ch
+Am|bool|isPUNCT|char ch
+Am|bool|isSPACE|char ch
+Am|bool|isUPPER|char ch
+Am|bool|isWORDCHAR|char ch
+Am|bool|isXDIGIT|char ch
+Am|bool|OpHAS_SIBLING|OP *o
+Am|bool|OpSIBLING|OP *o
+Am|bool|OpSIBLING_set|OP *o|OP *sib
+Am|bool|OP_TYPE_IS|OP *o|Optype type
+Am|bool|OP_TYPE_IS_OR_WAS|OP *o|Optype type
+Am|bool|strEQ|char* s1|char* s2
+Am|bool|strGE|char* s1|char* s2
+Am|bool|strGT|char* s1|char* s2
+Am|bool|strLE|char* s1|char* s2
+Am|bool|strLT|char* s1|char* s2
+Am|bool|strNE|char* s1|char* s2
+Am|bool|strnEQ|char* s1|char* s2|STRLEN len
+Am|bool|strnNE|char* s1|char* s2|STRLEN len
+Am|bool|SvIOK_notUV|SV* sv
+Am|bool|SvIOK_UV|SV* sv
+Am|bool|SvIsCOW_shared_hash|SV* sv
+Am|bool|SvRXOK|SV* sv
+Am|bool|SvTAINTED|SV* sv
+Am|bool|SvTRUE_nomg|SV* sv
+Am|bool|SvTRUE|SV* sv
+Am|bool|SvUOK|SV* sv
+Am|bool|SvVOK|SV* sv
+Am|char*|HePV|HE* he|STRLEN len
+Am|char*|HvENAME|HV* stash
+Am|char*|HvNAME|HV* stash
+Am|char*|SvEND|SV* sv
+Am|char *|SvGROW|SV* sv|STRLEN len
+Am|char*|SvPVbyte_force|SV* sv|STRLEN len
+Am|char*|SvPVbyte_nolen|SV* sv
+Am|char*|SvPVbyte|SV* sv|STRLEN len
+Am|char*|SvPVbytex_force|SV* sv|STRLEN len
+Am|char*|SvPVbytex|SV* sv|STRLEN len
+Am|char*|SvPV_force_nomg|SV* sv|STRLEN len
+Am|char*|SvPV_force|SV* sv|STRLEN len
+Am|char*|SvPV_nolen|SV* sv
+Am|char*|SvPV_nomg_nolen|SV* sv
+Am|char*|SvPV_nomg|SV* sv|STRLEN len
+Am|char*|SvPV|SV* sv|STRLEN len
+Am|char*|SvPVutf8_force|SV* sv|STRLEN len
+Am|char*|SvPVutf8_nolen|SV* sv
+Am|char*|SvPVutf8|SV* sv|STRLEN len
+Am|char*|SvPVutf8x_force|SV* sv|STRLEN len
+Am|char*|SvPVutf8x|SV* sv|STRLEN len
+Am|char*|SvPVX|SV* sv
+Am|char*|SvPVx|SV* sv|STRLEN len
+Am|const char *|OP_DESC|OP *o
+Am|const char *|OP_NAME|OP *o
+Am|CV*|GvCV|GV* gv
+Am|HV *|cop_hints_2hv|const COP *cop|U32 flags
+Am|HV*|CvSTASH|CV* cv
+Am|HV*|GvHV|GV* gv
+Am|HV*|gv_stashpvs|const char* name|I32 create
+Am|HV*|SvSTASH|SV* sv
+Am|int|AvFILL|AV* av
+Am|IV|SvIV_nomg|SV* sv
+Am|IV|SvIV|SV* sv
+Am|IV|SvIVx|SV* sv
+Am|IV|SvIVX|SV* sv
+Amn|char*|CLASS
+Amn|char*|POPp
+Amn|char*|POPpbytex
+Amn|char*|POPpx
 Amn|HV*|PL_modglobal
 Amn|I32|ax
 Amn|I32|items
 Amn|I32|ix
 Amn|IV|POPi
+Amn|long|POPl
 Amn|NV|POPn
+Amn|peep_t|PL_peepp
+Amn|peep_t|PL_rpeepp
 Amn|Perl_ophook_t|PL_opfreehook
 Amn|STRLEN|PL_na
-Amn|SV*|POPs
 Amn|SV|PL_sv_no
 Amn|SV|PL_sv_undef
 Amn|SV|PL_sv_yes
+Amn|SV*|POPs
 Amn|U32|GIMME
 Amn|U32|GIMME_V
 Amn|UV|POPu
@@ -104,6 +142,16 @@ Ams||XSRETURN_UNDEF
 Ams||XSRETURN_YES
 Ams||XS_APIVERSION_BOOTCHECK
 Ams||XS_VERSION_BOOTCHECK
+Am|NV|SvNV_nomg|SV* sv
+Am|NV|SvNV|SV* sv
+Am|NV|SvNVx|SV* sv
+Am|NV|SvNVX|SV* sv
+Amn|(whatever)|RETVAL
+Amn|(whatever)|THIS
+Am|OP*|LINKLIST|OP *o
+Am|PADOFFSET|pad_add_name_pvs|const char *name|U32 flags|HV *typestash|HV *ourstash
+Am|PADOFFSET|pad_findmy_pvs|const char *name|U32 flags
+Am|REGEXP *|SvRX|SV *sv
 Ams||dAX
 Ams||dAXMARK
 Ams||dITEMS
@@ -178,39 +226,56 @@ Am|NV|SvNV_nomg|SV* sv
 Am|NV|SvNVx|SV* sv
 Am|NV|SvNV|SV* sv
 Am|OP*|LINKLIST|OP *o
-Am|OP*|OpSIBLING|OP *o
 Am|PADOFFSET|pad_add_name_pvs|const char *name|U32 flags|HV *typestash|HV *ourstash
 Am|PADOFFSET|pad_findmy_pvs|const char *name|U32 flags
 Am|REGEXP *|SvRX|SV *sv
+Ams||ENTER
+Ams||FREETMPS
+Ams||LEAVE
+Ams||MULTICALL
+Ams||POP_MULTICALL
+Ams||PUSH_MULTICALL
+Ams||PUTBACK
+Ams||SAVETMPS
+Ams||SPAGAIN
 Am|STRLEN|HeKLEN|HE* he
 Am|STRLEN|HvENAMELEN|HV *stash
 Am|STRLEN|HvNAMELEN|HV *stash
+Am|STRLEN|isUTF8_CHAR|const U8 *s|const U8 *e
 Am|STRLEN|SvCUR|SV* sv
 Am|STRLEN|SvLEN|SV* sv
 Am|STRLEN|UTF8SKIP|char* s
 Am|STRLEN|UVCHR_SKIP|UV cp
 Am|STRLEN|isUTF8_CHAR|const U8 *s|const U8 *e
 Am|SV *|boolSV|bool b
+Am|SV *|cop_hints_fetch_pv|const COP *cop|const char *key|U32 hash|U32 flags
 Am|SV *|cop_hints_fetch_pvn|const COP *cop|const char *keypv|STRLEN keylen|U32 hash|U32 flags
 Am|SV *|cop_hints_fetch_pvs|const COP *cop|const char *key|U32 flags
-Am|SV *|cop_hints_fetch_pv|const COP *cop|const char *key|U32 hash|U32 flags
 Am|SV *|cop_hints_fetch_sv|const COP *cop|SV *key|U32 hash|U32 flags
-Am|SV *|sv_setref_pvs|const char* s
-Am|SV**|hv_fetchs|HV* tb|const char* key|I32 lval
-Am|SV**|hv_stores|HV* tb|const char* key|NULLOK SV* val
 Am|SV*|GvSV|GV* gv
 Am|SV*|HeSVKEY_force|HE* he
-Am|SV*|HeSVKEY_set|HE* he|SV* sv
 Am|SV*|HeSVKEY|HE* he
+Am|SV*|HeSVKEY_set|HE* he|SV* sv
 Am|SV*|HeVAL|HE* he
+Am|SV**|hv_fetchs|HV* tb|const char* key|I32 lval
+Am|SV**|hv_stores|HV* tb|const char* key|NULLOK SV* val
+Am|SV*|newRV_inc|SV* sv
+Am|SV*|newSVpvn_utf8|NULLOK const char* s|STRLEN len|U32 utf8
 Am|SV*|ST|int ix
 Am|SV*|SvREFCNT_inc_NN|SV* sv
 Am|SV*|SvREFCNT_inc_simple_NN|SV* sv
 Am|SV*|SvREFCNT_inc_simple|SV* sv
 Am|SV*|SvREFCNT_inc|SV* sv
 Am|SV*|SvRV|SV* sv
-Am|SV*|newRV_inc|SV* sv
-Am|SV*|newSVpvn_utf8|NULLOK const char* s|STRLEN len|U32 utf8
+Am|SV *|sv_setref_pvs|const char* s
+Am|svtype|SvTYPE|SV* sv
+Ams||XCPT_RETHROW
+Ams||XS_APIVERSION_BOOTCHECK
+Ams||XSRETURN_EMPTY
+Ams||XSRETURN_NO
+Ams||XSRETURN_UNDEF
+Ams||XSRETURN_YES
+Ams||XS_VERSION_BOOTCHECK
 Am|U32|HeHASH|HE* he
 Am|U32|HeUTF8|HE* he
 Am|U32|OP_CLASS|OP *o
@@ -237,10 +302,48 @@ Am|U8|toLOWER_LC|U8 ch
 Am|U8|toLOWER|U8 ch
 Am|U8|toTITLE|U8 ch
 Am|U8|toUPPER|U8 ch
-Am|UV|SvUVX|SV* sv
+AmU||G_ARRAY
+AmU||G_DISCARD
+AmU||G_EVAL
+AmU||G_NOARGS
+AmU||G_SCALAR
+AmU||G_VOID
+AmU||HEf_SVKEY
+AmU||MARK
+AmU||newXSproto|char* name|XSUBADDR_t f|char* filename|const char *proto
+Am|unsigned char|HvENAMEUTF8|HV *stash
+Am|unsigned char|HvNAMEUTF8|HV *stash
+AmU||Nullav
+AmU||Nullch
+AmU||Nullcv
+AmU||Nullhv
+AmU||Nullsv
+AmU||ORIGMARK
+AmU|Perl_check_t *|PL_check
+AmU||SP
+AmU||SVt_INVLIST
+AmU||SVt_IV
+AmU||SVt_NULL
+AmU||SVt_NV
+AmU||SVt_PV
+AmU||SVt_PVAV
+AmU||SVt_PVCV
+AmU||SVt_PVFM
+AmU||SVt_PVGV
+AmU||SVt_PVHV
+AmU||SVt_PVIO
+AmU||SVt_PVIV
+AmU||SVt_PVLV
+AmU||SVt_PVMG
+AmU||SVt_PVNV
+AmU||SVt_REGEXP
+AmU||svtype
+AmU||UNDERBAR
 Am|UV|SvUV_nomg|SV* sv
-Am|UV|SvUVx|SV* sv
 Am|UV|SvUV|SV* sv
+Am|UV|SvUVx|SV* sv
+Am|UV|SvUVX|SV* sv
+Am|UV|toFOLD_uni|UV cp|U8* s|STRLEN* lenp
 Am|UV|toFOLD_utf8|U8* p|U8* s|STRLEN* lenp
 Am|UV|toFOLD_uvchr|UV cp|U8* s|STRLEN* lenp
 Am|UV|toLOWER_utf8|U8* p|U8* s|STRLEN* lenp
@@ -319,24 +422,46 @@ Am|int|AvFILL|AV* av
 Am|svtype|SvTYPE|SV* sv
 Am|unsigned char|HvENAMEUTF8|HV *stash
 Am|unsigned char|HvNAMEUTF8|HV *stash
+AmU||XCPT_CATCH
+AmU||XCPT_TRY_END
+AmU||XCPT_TRY_START
+AmUx|Perl_keyword_plugin_t|PL_keyword_plugin
+AmU||XS
+AmU||XS_EXTERNAL
+AmU||XS_INTERNAL
+AmU||XS_VERSION
+AmU|yy_parser *|PL_parser
 Am|void *|CopyD|void* src|void* dest|int nitems|type
-Am|void *|MoveD|void* src|void* dest|int nitems|type
-Am|void *|ZeroD|void* dest|int nitems|type
-Am|void*|HeKEY|HE* he
 Am|void|Copy|void* src|void* dest|int nitems|type
 Am|void|EXTEND|SP|SSize_t nitems
+Am|void*|HeKEY|HE* he
+Am|void *|MoveD|void* src|void* dest|int nitems|type
 Am|void|Move|void* src|void* dest|int nitems|type
+Am|void|mPUSHi|IV iv
+Am|void|mPUSHn|NV nv
+Am|void|mPUSHp|char* str|STRLEN len
+Am|void|mPUSHs|SV* sv
+Am|void|mPUSHu|UV uv
+Am|void|mXPUSHi|IV iv
+Am|void|mXPUSHn|NV nv
+Am|void|mXPUSHp|char* str|STRLEN len
+Am|void|mXPUSHs|SV* sv
+Am|void|mXPUSHu|UV uv
 Am|void|Newxc|void* ptr|int nitems|type|cast
-Am|void|Newxz|void* ptr|int nitems|type
 Am|void|Newx|void* ptr|int nitems|type
+Am|void|Newxz|void* ptr|int nitems|type
 Am|void|OpLASTSIB_set|OP *o|OP *parent
 Am|void|OpMAYBESIB_set|OP *o|OP *sib|OP *parent
 Am|void|OpMORESIB_set|OP *o|OP *sib
 Am|void|PERL_SYS_INIT3|int *argc|char*** argv|char*** env
 Am|void|PERL_SYS_INIT|int *argc|char*** argv
 Am|void|PERL_SYS_TERM|
-Am|void|PUSHMARK|SP
+Am|void|PoisonFree|void* dest|int nitems|type
+Am|void|PoisonNew|void* dest|int nitems|type
+Am|void|Poison|void* dest|int nitems|type
+Am|void|PoisonWith|void* dest|int nitems|type|U8 byte
 Am|void|PUSHi|IV iv
+Am|void|PUSHMARK|SP
 Am|void|PUSHmortal
 Am|void|PUSHn|NV nv
 Am|void|PUSHp|char* str|STRLEN len
@@ -346,18 +471,25 @@ Am|void|PoisonFree|void* dest|int nitems|type
 Am|void|PoisonNew|void* dest|int nitems|type
 Am|void|PoisonWith|void* dest|int nitems|type|U8 byte
 Am|void|Poison|void* dest|int nitems|type
-Am|void|RESTORE_LC_NUMERIC
 Am|void|Renewc|void* ptr|int nitems|type|cast
 Am|void|Renew|void* ptr|int nitems|type
+Am|void|RESTORE_LC_NUMERIC
 Am|void|STORE_LC_NUMERIC_FORCE_TO_UNDERLYING
 Am|void|STORE_LC_NUMERIC_SET_TO_NEEDED
 Am|void|Safefree|void* ptr
 Am|void|StructCopy|type *src|type *dest|type
+Am|void|sv_catpvn_nomg|SV* sv|const char* ptr|STRLEN len
+Am|void|sv_catpv_nomg|SV* sv|const char* ptr
+Am|void|sv_catpvs_flags|SV* sv|const char* s|I32 flags
+Am|void|sv_catpvs_mg|SV* sv|const char* s
+Am|void|sv_catpvs_nomg|SV* sv|const char* s
+Am|void|sv_catpvs|SV* sv|const char* s
+Am|void|sv_catsv_nomg|SV* dsv|SV* ssv
 Am|void|SvCUR_set|SV* sv|STRLEN len
 Am|void|SvGETMAGIC|SV* sv
 Am|void|SvIOK_off|SV* sv
-Am|void|SvIOK_only_UV|SV* sv
 Am|void|SvIOK_only|SV* sv
+Am|void|SvIOK_only_UV|SV* sv
 Am|void|SvIOK_on|SV* sv
 Am|void|SvIV_set|SV* sv|IV val
 Am|void|SvLEN_set|SV* sv|STRLEN len
@@ -370,8 +502,8 @@ Am|void|SvNOK_on|SV* sv
 Am|void|SvNV_set|SV* sv|NV val
 Am|void|SvOOK_offset|NN SV*sv|STRLEN len
 Am|void|SvPOK_off|SV* sv
-Am|void|SvPOK_only_UTF8|SV* sv
 Am|void|SvPOK_only|SV* sv
+Am|void|SvPOK_only_UTF8|SV* sv
 Am|void|SvPOK_on|SV* sv
 Am|void|SvPV_set|SV* sv|char* val
 Am|void|SvREFCNT_dec_NN|SV* sv
@@ -383,13 +515,16 @@ Am|void|SvREFCNT_inc_void|SV* sv
 Am|void|SvROK_off|SV* sv
 Am|void|SvROK_on|SV* sv
 Am|void|SvRV_set|SV* sv|SV* val
-Am|void|SvSETMAGIC|SV* sv
-Am|void|SvSHARE|SV* sv
-Am|void|SvSTASH_set|SV* sv|HV* val
 Am|void|SvSetMagicSV_nosteal|SV* dsv|SV* ssv
+Am|void|SvSETMAGIC|SV* sv
 Am|void|SvSetMagicSV|SV* dsv|SV* ssv
+Am|void|sv_setpvs_mg|SV* sv|const char* s
+Am|void|sv_setpvs|SV* sv|const char* s
+Am|void|sv_setsv_nomg|SV* dsv|SV* ssv
 Am|void|SvSetSV_nosteal|SV* dsv|SV* ssv
 Am|void|SvSetSV|SV* dsv|SV* ssv
+Am|void|SvSHARE|SV* sv
+Am|void|SvSTASH_set|SV* sv|HV* val
 Am|void|SvTAINTED_off|SV* sv
 Am|void|SvTAINTED_on|SV* sv
 Am|void|SvTAINT|SV* sv
@@ -398,88 +533,116 @@ Am|void|SvUPGRADE|SV* sv|svtype type
 Am|void|SvUTF8_off|SV *sv
 Am|void|SvUTF8_on|SV *sv
 Am|void|SvUV_set|SV* sv|UV val
+Am|void|XopDISABLE|XOP *xop|which
+Am|void|XopENABLE|XOP *xop|which
+Am|void|XopENTRY_set|XOP *xop|which|value
 Am|void|XPUSHi|IV iv
 Am|void|XPUSHmortal
 Am|void|XPUSHn|NV nv
 Am|void|XPUSHp|char* str|STRLEN len
 Am|void|XPUSHs|SV* sv
 Am|void|XPUSHu|UV uv
+Am|void|XSRETURN|int nitems
 Am|void|XSRETURN_IV|IV iv
 Am|void|XSRETURN_NV|NV nv
 Am|void|XSRETURN_PV|char* str
 Am|void|XSRETURN_UV|IV uv
-Am|void|XSRETURN|int nitems
 Am|void|XST_mIV|int pos|IV iv
 Am|void|XST_mNO|int pos
 Am|void|XST_mNV|int pos|NV nv
 Am|void|XST_mPV|int pos|char* str
 Am|void|XST_mUNDEF|int pos
 Am|void|XST_mYES|int pos
-Am|void|XopDISABLE|XOP *xop|which
-Am|void|XopENABLE|XOP *xop|which
-Am|void|XopENTRY_set|XOP *xop|which|value
+Am|void *|ZeroD|void* dest|int nitems|type
 Am|void|Zero|void* dest|int nitems|type
-Am|void|mPUSHi|IV iv
-Am|void|mPUSHn|NV nv
-Am|void|mPUSHp|char* str|STRLEN len
-Am|void|mPUSHs|SV* sv
-Am|void|mPUSHu|UV uv
-Am|void|mXPUSHi|IV iv
-Am|void|mXPUSHn|NV nv
-Am|void|mXPUSHp|char* str|STRLEN len
-Am|void|mXPUSHs|SV* sv
-Am|void|mXPUSHu|UV uv
-Am|void|sv_catpv_nomg|SV* sv|const char* ptr
-Am|void|sv_catpvn_nomg|SV* sv|const char* ptr|STRLEN len
-Am|void|sv_catpvs_flags|SV* sv|const char* s|I32 flags
-Am|void|sv_catpvs_mg|SV* sv|const char* s
-Am|void|sv_catpvs_nomg|SV* sv|const char* s
-Am|void|sv_catpvs|SV* sv|const char* s
-Am|void|sv_catsv_nomg|SV* dsv|SV* ssv
-Am|void|sv_setpvs_mg|SV* sv|const char* s
-Am|void|sv_setpvs|SV* sv|const char* s
-Am|void|sv_setsv_nomg|SV* dsv|SV* ssv
+Amx|bool|PadnameUTF8|PADNAME pn
+Amx|char *|PadnamePV|PADNAME pn
+Amx|COPHH *|cophh_copy|COPHH *cophh
+Amx|COPHH *|cophh_delete_pv|const COPHH *cophh|const char *key|U32 hash|U32 flags
+Amx|COPHH *|cophh_delete_pvn|COPHH *cophh|const char *keypv|STRLEN keylen|U32 hash|U32 flags
+Amx|COPHH *|cophh_delete_pvs|const COPHH *cophh|const char *key|U32 flags
+Amx|COPHH *|cophh_delete_sv|const COPHH *cophh|SV *key|U32 hash|U32 flags
+Amx|COPHH *|cophh_new_empty
+Amx|COPHH *|cophh_store_pv|const COPHH *cophh|const char *key|U32 hash|SV *value|U32 flags
+Amx|COPHH *|cophh_store_pvn|COPHH *cophh|const char *keypv|STRLEN keylen|U32 hash|SV *value|U32 flags
+Amx|COPHH *|cophh_store_pvs|const COPHH *cophh|const char *key|SV *value|U32 flags
+Amx|COPHH *|cophh_store_sv|const COPHH *cophh|SV *key|U32 hash|SV *value|U32 flags
+Amx|HV *|cophh_2hv|const COPHH *cophh|U32 flags
 Am||XopENTRYCUSTOM|const OP *o|which
 Am||XopENTRY|XOP *xop|which
-mU||LVRET
+Amx|PADLIST *|CvPADLIST|CV *cv
+Amx|PADNAMELIST *|PadlistNAMES|PADLIST padlist
+Amx|PADNAME **|PadlistNAMESARRAY|PADLIST padlist
+Amx|PADNAME **|PadnamelistARRAY|PADNAMELIST pnl
+Amx|PAD **|PadlistARRAY|PADLIST padlist
+Amx|SSize_t|PadlistMAX|PADLIST padlist
+Amx|SSize_t|PadlistNAMESMAX|PADLIST padlist
+Amx|SSize_t|PadMAX|PAD pad
+Amx|SSize_t|PadnamelistMAX|PADNAMELIST pnl
+Amx|SSize_t|PadnamelistREFCNT|PADNAMELIST pnl
+Amx|SSize_t|PadnameREFCNT|PADNAME pn
+Amx|STRLEN|PadnameLEN|PADNAME pn
+Amx|SV *|cophh_fetch_pv|const COPHH *cophh|const char *key|U32 hash|U32 flags
+Amx|SV *|cophh_fetch_pvn|const COPHH *cophh|const char *keypv|STRLEN keylen|U32 hash|U32 flags
+Amx|SV *|cophh_fetch_pvs|const COPHH *cophh|const char *key|U32 flags
+Amx|SV *|cophh_fetch_sv|const COPHH *cophh|SV *key|U32 hash|U32 flags
+Amx|SV*|newSVpadname|PADNAME *pn
+Amx|SV **|PadARRAY|PAD pad
+Amx|SV *|PadnameSV|PADNAME pn
+Amx|U32|PadlistREFCNT|PADLIST padlist
+AmxU|char *|PL_parser-E<gt>bufend
+AmxU|char *|PL_parser-E<gt>bufptr
+AmxU|char *|PL_parser-E<gt>linestart
+AmxU|PADNAMELIST *|PL_comppad_name
+AmxU|PAD *|PL_comppad
+AmxU|SV **|PL_curpad
+AmxU|SV *|PL_parser-E<gt>linestr
+Amx|void|BhkDISABLE|BHK *hk|which
+Amx|void|BhkENABLE|BHK *hk|which
+Amx|void|BhkENTRY_set|BHK *hk|which|void *ptr
+Amx|void|cophh_free|COPHH *cophh
+Amx|void|lex_stuff_pvs|const char *pv|U32 flags
+Amx|void|PadnamelistREFCNT_dec|PADNAMELIST pnl
+Amx|void|PadnameREFCNT_dec|PADNAME pn
+m|bool|CvWEAKOUTSIDE|CV *cv
+m|bool|PadnameIsOUR|PADNAME pn
+m|bool|PadnameIsSTATE|PADNAME pn
+m|bool|PadnameOUTER|PADNAME pn
+m|char *|PAD_COMPNAME_PV|PADOFFSET po
+m|HV *|PAD_COMPNAME_OURSTASH|PADOFFSET po
+m|HV *|PAD_COMPNAME_TYPE|PADOFFSET po
+m|HV *|PadnameOURSTASH
+m|HV *|PadnameTYPE|PADNAME pn
+mn|bool|PL_dowarn
 mn|GV *|PL_DBsub
 mn|GV*|PL_last_in_gv
 mn|GV*|PL_ofsgv
 mn|SV *|PL_DBsingle
 mn|SV *|PL_DBtrace
 mn|SV*|PL_rs
-mn|bool|PL_dowarn
 ms||djSP
-mx|U32|BhkFLAGS|BHK *hk
-mx|void *|BhkENTRY|BHK *hk|which
-mx|void|CALL_BLOCK_HOOKS|which|arg
-m|HV *|PAD_COMPNAME_OURSTASH|PADOFFSET po
-m|HV *|PAD_COMPNAME_TYPE|PADOFFSET po
-m|HV *|PadnameOURSTASH
-m|HV *|PadnameTYPE|PADNAME pn
-m|STRLEN|PAD_COMPNAME_GEN_set|PADOFFSET po|int gen
 m|STRLEN|PAD_COMPNAME_GEN|PADOFFSET po
+m|STRLEN|PAD_COMPNAME_GEN_set|PADOFFSET po|int gen
+m|struct refcounted_he *|refcounted_he_new_pvs|struct refcounted_he *parent|const char *key|SV *value|U32 flags
 m|SV *|CX_CURPAD_SV|struct context|PADOFFSET po
 m|SV *|PAD_BASE_SV	|PADLIST padlist|PADOFFSET po
 m|SV *|PAD_SETSV	|PADOFFSET po|SV* sv
-m|SV *|PAD_SV	|PADOFFSET po
 m|SV *|PAD_SVl	|PADOFFSET po
+m|SV *|PAD_SV	|PADOFFSET po
 m|SV *|refcounted_he_fetch_pvs|const struct refcounted_he *chain|const char *key|U32 flags
 m|U32|PAD_COMPNAME_FLAGS|PADOFFSET po
 m|U32|SvTHINKFIRST|SV *sv
-m|bool|CvWEAKOUTSIDE|CV *cv
-m|bool|PadnameIsOUR|PADNAME pn
-m|bool|PadnameIsSTATE|PADNAME pn
-m|bool|PadnameOUTER|PADNAME pn
-m|char *|PAD_COMPNAME_PV|PADOFFSET po
-m|struct refcounted_he *|refcounted_he_new_pvs|struct refcounted_he *parent|const char *key|SV *value|U32 flags
+mU||LVRET
 m|void|CX_CURPAD_SAVE|struct context
 m|void|PAD_CLONE_VARS|PerlInterpreter *proto_perl|CLONE_PARAMS* param
 m|void|PAD_RESTORE_LOCAL|PAD *opad
 m|void|PAD_SAVE_LOCAL|PAD *opad|PAD *npad
 m|void|PAD_SAVE_SETNULLPAD
-m|void|PAD_SET_CUR	|PADLIST padlist|I32 n
 m|void|PAD_SET_CUR_NOSAVE	|PADLIST padlist|I32 n
+m|void|PAD_SET_CUR	|PADLIST padlist|I32 n
 m|void|SAVECLEARSV	|SV **svp
 m|void|SAVECOMPPAD
 m|void|SAVEPADSV	|PADOFFSET po
+mx|U32|BhkFLAGS|BHK *hk
+mx|void *|BhkENTRY|BHK *hk|which
+mx|void|CALL_BLOCK_HOOKS|which|arg

--- a/parts/inc/HvNAME
+++ b/parts/inc/HvNAME
@@ -1,6 +1,7 @@
 ################################################################################
 ##
 ##  Version 3.x, Copyright (C) 2004-2013, Marcus Holland-Moritz.
+##               Copyright (C) 2015, cPanel Inc.
 ##  Version 2.x, Copyright (C) 2001, Paul Marquess.
 ##  Version 1.x, Copyright (C) 1999, Kenneth Albanowski.
 ##
@@ -15,9 +16,19 @@ __UNDEFINED__
 
 =implementation
 
-__UNDEFINED__ HvNAME_get(hv) HvNAME(hv)
-
+__UNDEFINED__ HvNAME_get(hv)    HvNAME(hv)
 __UNDEFINED__ HvNAMELEN_get(hv) (HvNAME_get(hv) ? (I32)strlen(HvNAME_get(hv)) : 0)
+__UNDEFINED__ HvNAMELEN(hv)     HvNAMELEN_get(hv)
+__UNDEFINED__ HvENAME(hv)       HvNAME(hv)
+__UNDEFINED__ HvENAMELEN(hv)    (HvENAME(hv) ? strlen(HvENAME(hv)) : 0)
+
+# if { VERSION < 5.10.0 }
+__UNDEFINED__ HvNAMEUTF8(hv)    0
+__UNDEFINED__ HvENAMEUTF8(hv)   0
+#else
+__UNDEFINED__ HvNAMEUTF8(hv)    (HvNAME_HEK(hv) ? HEK_UTF8(HvNAME_HEK(hv)) : 0)
+__UNDEFINED__ HvENAMEUTF8(hv)   HvNAMEUTF8(hv)
+#endif
 
 =xsubs
 
@@ -29,10 +40,46 @@ int
 HvNAMELEN_get(hv)
         HV *hv
 
-=tests plan => 4
+int
+HvNAMELEN(hv)
+        HV *hv
+
+int
+HvNAMEUTF8(hv)
+        HV *hv
+
+char *
+HvENAME(hv)
+        HV *hv
+
+int
+HvENAMELEN(hv)
+        HV *hv
+
+int
+HvENAMEUTF8(hv)
+        HV *hv
+
+=tests plan => 11
 
 ok(Devel::PPPort::HvNAME_get(\%Devel::PPPort::), 'Devel::PPPort');
 ok(Devel::PPPort::HvNAME_get({}), undef);
 
 ok(Devel::PPPort::HvNAMELEN_get(\%Devel::PPPort::), length('Devel::PPPort'));
 ok(Devel::PPPort::HvNAMELEN_get({}), 0);
+
+ok(Devel::PPPort::HvNAMELEN({}), 0);
+ok(Devel::PPPort::HvENAME({}), undef);
+ok(Devel::PPPort::HvENAMELEN({}), 0);
+ok(Devel::PPPort::HvENAMEUTF8({}), 0);
+
+ok(Devel::PPPort::HvNAMEUTF8(\%Devel::PPPort::), 0);
+
+if ($] > 5.015006) {
+   use utf8;
+   ok(Devel::PPPort::HvNAMEUTF8(\%αaαb::), 1);
+   ok(Devel::PPPort::HvENAMEUTF8(\%αaαb::), 1);
+} else {
+  ok(1, 1, "skip HvNAMEUTF8 with $]");
+  ok(1, 1, "skip HvENAMEUTF8 with $]");
+}

--- a/parts/inc/gv
+++ b/parts/inc/gv
@@ -31,7 +31,45 @@ gv_fetchpvn_flags(pTHX_ const char* name, STRLEN len, int flags, int types) {
 
 __UNDEFINED__ GvSVn(gv)        GvSV(gv)
 __UNDEFINED__ isGV_with_GP(gv) isGV(gv)
-__UNDEFINED__ gv_fetchsv(name, flags, svt) gv_fetchpv(SvPV_nolen_const(name), flags, svt)
+__UNDEFINED__ gv_fetchpvn_flags(name, len, flags, svt) gv_fetchpv(name, flags, svt)
+__UNDEFINED__ gv_fetchpvn(name, len, flags, svt) gv_fetchpvn_flags(name, len, flags, svt)
+__UNDEFINED__ gv_fetchsv(name, flags, svt) gv_fetchpvn_flags(SvPV_nolen_const(name), SvCUR(name), flags, svt)
+
+__UNDEFINED__ gv_fetchmethod_flags(stash,name,flags) gv_fetchmethod_pv_flags(stash, name, flags)
+
+#if !defined(gv_init_pv)
+#if { NEED gv_init_pv }
+SV *
+gv_init_pv(GV *gv, HV *stash, char *name, U32 flags) {
+   if (SvUTF8(namesv))
+       flags |= SVf_UTF8;
+   gv_init_pvn(gv, stash, name, strlen(name), flags);
+}
+#endif
+#endif
+
+#if !defined(gv_init_pvn)
+#if { NEED gv_init_pvn }
+SV *
+gv_init_pvn(GV *gv, HV *stash, const char *name, STRLEN len, U32 flags) {
+   gv_init(gv, stash, name, len, flags);
+}
+#endif
+#endif
+
+#if !defined(gv_init_sv)
+#if { NEED gv_init_sv }
+SV *
+gv_init_sv(GV *gv, HV *stash, SV* namesv, U32 flags) {
+   char *namepv;
+   STRLEN namelen;
+   namepv = SvPV(namesv, namelen);
+   if (SvUTF8(namesv))
+       flags |= SVf_UTF8;
+   gv_init_pvn(gv, stash, namepv, namelen, flags);
+}
+#endif
+#endif
 
 __UNDEFINED__ get_cvn_flags(name, namelen, flags) get_cv(name, flags)
 __UNDEFINED__ gv_init_pvn(gv, stash, ptr, len, flags) gv_init(gv, stash, ptr, len, flags & GV_ADDMULTI ? TRUE : FALSE)
@@ -101,6 +139,13 @@ gv_fetchpvn_flags()
                 RETVAL
 
 SV*
+gv_fetchpvn()
+        CODE:
+                RETVAL = newRV_inc((SV*)gv_fetchpvn("Devel::PPPort::VERSION", sizeof("Devel::PPPort::VERSION")-1, 0, SVt_PV));
+        OUTPUT:
+                RETVAL
+
+SV*
 gv_fetchsv(name)
         SV *name
         CODE:
@@ -125,7 +170,7 @@ gv_init_type(namesv, multi, flags)
         gv_init_pvn(gv, defstash, name, len, flags);
 	XPUSHs( gv ? (SV*)gv : &PL_sv_undef);
 
-=tests plan => 7
+=tests plan => 8
 
 ok(Devel::PPPort::GvSVn(), 1);
 
@@ -134,6 +179,8 @@ ok(Devel::PPPort::isGV_with_GP(), 2);
 ok(Devel::PPPort::get_cvn_flags(), 3);
 
 ok(Devel::PPPort::gv_fetchpvn_flags(), \*Devel::PPPort::VERSION);
+
+ok(Devel::PPPort::gv_fetchpvn(), \*Devel::PPPort::VERSION);
 
 ok(Devel::PPPort::gv_fetchsv("Devel::PPPort::VERSION"), \*Devel::PPPort::VERSION);
 

--- a/parts/todo/5013007
+++ b/parts/todo/5013007
@@ -1,5 +1,4 @@
 5.013007
-HvENAME                        # U
 OP_CLASS                       # U
 XopFLAGS                       # E
 amagic_deref_call              # U

--- a/parts/todo/5015004
+++ b/parts/todo/5015004
@@ -1,8 +1,4 @@
 5.015004
-HvENAMELEN                     # U
-HvENAMEUTF8                    # U
-HvNAMELEN                      # U
-HvNAMEUTF8                     # U
 gv_autoload_pv                 # U
 gv_autoload_pvn                # U
 gv_autoload_sv                 # U
@@ -12,7 +8,11 @@ gv_fetchmeth_pvn               # U
 gv_fetchmeth_pvn_autoload      # U
 gv_fetchmeth_sv                # U
 gv_fetchmeth_sv_autoload       # U
+gv_fetchmethod_pv_flags        # U
+gv_fetchmethod_pvn_flags       # U
+gv_fetchmethod_sv_flags        # U
 gv_init_pv                     # U
+gv_init_pvn                    # U
 gv_init_sv                     # U
 newGVgen_flags                 # U
 sv_derived_from_pv             # U


### PR DESCRIPTION
Add HvNAMELEN, HvNAMEUTF8, HvENAME, HvENAMELEN, HvENAMEUTF8
gv_fetchpvn, gv_fetchmethod_flags, gv_init_pv, gv_init_pvn, gv_init_sv

Tested ok on all major perl versions down to 5.6.2
