### PR TITLE
Fix character classification macros, like isDIGIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pm_to_blib
 /RealPPPort.*
 /ppport.h
 /t/*.t
+/*.o

--- a/Changes
+++ b/Changes
@@ -1,3 +1,24 @@
+pending
+
+    * Don't override the WIDEST_UTYPE macro if it already exists
+    * Fix the isFOO character type classification macros to work properly on
+      all versions, as follows:
+        * Fixed isALNUM, isALPHA, isDIGIT, isIDFIRST, isLOWER, and isUPPER on
+          very early perls to not be locale-dependent
+        * Fixed isASCII on early perls to work with signed char arguments
+        * Fixed isCNTRL on early perls to know that DEL is a control
+        * Fixed isSPACE on perls before 5.20 to know that VERTICAL TAB is a
+          space
+        * Added isALPHANUMERIC, synonym for isALNUMC
+        * Added isIDCONT, to match legal non-initial characters in an
+          identifier
+        * Added isOCTAL, to match [0-7]
+        * Added isWORDCHAR, synonym for isALNUM
+        * Make all the character classification isFOO macros work on EBCDIC
+          platforms on all versions
+        * Added isFOO_A synonyms for all character classification isFOO
+          macros
+
 3.35 - 2016-06-17
 
     * Fix compilation in bleadperl by removing a bad test.

--- a/HACKERS
+++ b/HACKERS
@@ -232,18 +232,24 @@ instead of
   #  define macro    some definition
   #endif
 
-The macro can have optional arguments and the definition can even
+If you use this, you don't have to list C<"macro"> in the C<=provides> section.
+But that section must contain a single line
+
+ __UNDEFINED__
+
+which acts as a stand-in for all the macros defined through its use.
+
+C<"macro"> can have optional arguments and the definition can even
 span multiple lines, like in
 
   __UNDEFINED__ SvMAGIC_set(sv, val) \
                 STMT_START { assert(SvTYPE(sv) >= SVt_PVMG); \
                 (((XPVMG*) SvANY(sv))->xmg_magic = (val)); } STMT_END
 
-This usually makes the code more compact and readable. And you
-only have to add C<__UNDEFINED__> to the C<=provides> section.
+This usually makes the code more compact and readable.
 
-Version checking can be tricky if you want to do it correct.
-You can use
+Version checking can be tricky if you want to do it correctly.
+C<Devel::PPPort> provides a facility to make it easier.  You can use
 
   #if { VERSION < 5.9.3 }
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -83,7 +83,7 @@ sub configure
     # Devel::PPPort is in the core since 5.7.3
     # 5.11.0+ has site before perl
     push @moreopts, INSTALLDIRS => (
-      ($] >= 5.007003 and $] < 5.011)
+      ("$]" >= 5.007003 and "$]" < 5.011)
         ? 'perl'
         : 'site'
     );

--- a/PPPort_pm.PL
+++ b/PPPort_pm.PL
@@ -620,6 +620,8 @@ __DATA__
 
 %include memory
 
+%include magic_defs
+
 %include misc
 
 %include variables

--- a/parts/base/5005000
+++ b/parts/base/5005000
@@ -9,7 +9,6 @@ fbm_instr                      # E (Perl_fbm_instr)
 get_op_descs                   # E
 get_op_names                   # E
 init_stacks                    # E
-mg_length                      # E
 mg_size                        # E
 newHVhv                        # E
 new_stackinfo                  # E

--- a/parts/base/5006000
+++ b/parts/base/5006000
@@ -67,54 +67,11 @@ get_hv                         # E (perl_get_hv)
 get_ppaddr                     # E
 get_sv                         # E (perl_get_sv)
 gv_dump                        # E
-init_i18nl10n                  # E (perl_init_i18nl10n)
-init_i18nl14n                  # E (perl_init_i18nl14n)
 isASCII                        # U
 isCNTRL                        # U
 isGRAPH                        # U
 isPUNCT                        # U
 isXDIGIT                       # U
-is_uni_alnum                   # E
-is_uni_alnum_lc                # E
-is_uni_alpha                   # E
-is_uni_alpha_lc                # E
-is_uni_ascii                   # E
-is_uni_ascii_lc                # E
-is_uni_cntrl                   # E
-is_uni_cntrl_lc                # E
-is_uni_digit                   # E
-is_uni_digit_lc                # E
-is_uni_graph                   # E
-is_uni_graph_lc                # E
-is_uni_idfirst                 # E
-is_uni_idfirst_lc              # E
-is_uni_lower                   # E
-is_uni_lower_lc                # E
-is_uni_print                   # E
-is_uni_print_lc                # E
-is_uni_punct                   # E
-is_uni_punct_lc                # E
-is_uni_space                   # E
-is_uni_space_lc                # E
-is_uni_upper                   # E
-is_uni_upper_lc                # E
-is_uni_xdigit                  # E
-is_uni_xdigit_lc               # E
-is_utf8_alnum                  # E
-is_utf8_alpha                  # E
-is_utf8_ascii                  # E
-is_utf8_char                   # U
-is_utf8_cntrl                  # E
-is_utf8_digit                  # E
-is_utf8_graph                  # E
-is_utf8_idfirst                # E
-is_utf8_lower                  # E
-is_utf8_mark                   # E
-is_utf8_print                  # E
-is_utf8_punct                  # E
-is_utf8_space                  # E
-is_utf8_upper                  # E
-is_utf8_xdigit                 # E
 load_module                    # E
 magic_dump                     # E
 mess                           # E (Perl_mess)
@@ -127,9 +84,6 @@ newSVpvf                       # E (Perl_newSVpvf)
 newSVuv                        # E
 newXS                          # E (Perl_newXS)
 newXSproto                     # E
-new_collate                    # E (perl_new_collate)
-new_ctype                      # E (perl_new_ctype)
-new_numeric                    # E (perl_new_numeric)
 op_dump                        # E
 perl_parse                     # E (perl_parse)
 pmop_dump                      # E
@@ -180,17 +134,11 @@ sv_setnv_mg                    # E (Perl_sv_setnv_mg)
 sv_setpvf                      # E (Perl_sv_setpvf)
 sv_setpvf_mg                   # E (Perl_sv_setpvf_mg)
 sv_setref_nv                   # E (Perl_sv_setref_nv)
-sv_utf8_decode                 # E
-sv_utf8_downgrade              # E
 sv_utf8_encode                 # E
 sv_vcatpvf                     # E
 sv_vcatpvf_mg                  # E
 sv_vsetpvf                     # E
 sv_vsetpvf_mg                  # E
-swash_init                     # E
-to_uni_lower_lc                # E
-to_uni_title_lc                # E
-to_uni_upper_lc                # E
 utf8_distance                  # E
 utf8_hop                       # U
 vcroak                         # E

--- a/parts/base/5006001
+++ b/parts/base/5006001
@@ -1,7 +1,5 @@
 5.006001
 SvGAMAGIC                      # U
-apply_attrs_string             # U
-bytes_to_utf8                  # U
 gv_efullname4                  # U
 gv_fullname4                   # U
 isBLANK                        # U
@@ -10,7 +8,6 @@ is_utf8_string                 # U
 save_generic_pvref             # U
 utf16_to_utf8                  # E (Perl_utf16_to_utf8)
 utf16_to_utf8_reversed         # E (Perl_utf16_to_utf8_reversed)
-utf8_to_bytes                  # U
 G_METHOD                       # added by devel/scanprov
 NVef                           # added by devel/scanprov
 NVff                           # added by devel/scanprov

--- a/parts/base/5007001
+++ b/parts/base/5007001
@@ -1,9 +1,6 @@
 5.007001
-ASCII_TO_NEED                  # U
-NATIVE_TO_NEED                 # U
 POPpbytex                      # E
 SvUOK                          # U
-bytes_from_utf8                # U
 despatch_signals               # U
 do_openn                       # U
 gv_handler                     # U
@@ -17,8 +14,6 @@ sv_setref_uv                   # U
 sv_unref_flags                 # U
 sv_utf8_upgrade                # E (Perl_sv_utf8_upgrade)
 utf8_length                    # U
-utf8_to_uvchr                  # U
-utf8_to_uvuni                  # U
 utf8n_to_uvchr                 # U
 utf8n_to_uvuni                 # U
 uvchr_to_utf8                  # U

--- a/parts/base/5007002
+++ b/parts/base/5007002
@@ -25,7 +25,6 @@ sv_setsv_flags                 # U
 sv_setsv_nomg                  # U
 sv_utf8_upgrade_flags          # U
 sv_utf8_upgrade_nomg           # U
-swash_fetch                    # E (Perl_swash_fetch)
 GROK_NUMERIC_RADIX             # added by devel/scanprov
 IN_LOCALE                      # added by devel/scanprov
 IN_LOCALE_COMPILETIME          # added by devel/scanprov

--- a/parts/base/5007003
+++ b/parts/base/5007003
@@ -53,11 +53,6 @@ sv_nosharing                   # U
 sv_pvn_nomg                    # U
 sv_recode_to_utf8              # U
 sv_uni_display                 # U
-to_uni_fold                    # U
-to_uni_lower                   # E (Perl_to_uni_lower)
-to_uni_title                   # E (Perl_to_uni_title)
-to_uni_upper                   # E (Perl_to_uni_upper)
-to_utf8_case                   # U
 unpack_str                     # U
 uvchr_to_utf8_flags            # U
 uvuni_to_utf8_flags            # U

--- a/parts/base/5008000
+++ b/parts/base/5008000
@@ -1,8 +1,5 @@
 5.008000
 Poison                         # E
-hv_iternext_flags              # U
-hv_store_flags                 # U
-is_utf8_idcont                 # U
 nothreadhook                   # U
 WARN_LAYER                     # added by devel/scanprov
 WARN_THREADS                   # added by devel/scanprov

--- a/parts/base/5008001
+++ b/parts/base/5008001
@@ -9,7 +9,6 @@ is_utf8_string_loc             # U
 packlist                       # U
 pad_add_anon                   # U
 pad_new                        # E
-pad_tidy                       # E
 save_bool                      # U
 savestack_grow_cnt             # U
 seed                           # U

--- a/parts/base/5009002
+++ b/parts/base/5009002
@@ -12,7 +12,6 @@ XPUSHmortal                    # E
 ZeroD                          # E
 dUNDERBAR                      # E
 dXCPT                          # E
-find_rundefsvoffset            # U
 gv_fetchpvn_flags              # U
 gv_fetchsv                     # U
 mPUSHi                         # U

--- a/parts/base/5009004
+++ b/parts/base/5009004
@@ -17,10 +17,8 @@ my_snprintf                    # U
 my_strlcat                     # U
 my_strlcpy                     # U
 my_vsnprintf                   # U
-newXS_flags                    # U
 pv_escape                      # U
 pv_pretty                      # U
-regclass_swash                 # E (Perl_regclass_swash)
 sv_does                        # U
 sv_setpvs                      # U
 sv_usepvn_flags                # U

--- a/parts/base/5009005
+++ b/parts/base/5009005
@@ -1,19 +1,14 @@
 5.009005
 PL_parser                      # E
-Perl_signbit                   # U
 SvRX                           # U
 SvRXOK                         # U
-av_create_and_push             # U
-av_create_and_unshift_one      # U
 get_cvn_flags                  # U
 gv_fetchfile_flags             # U
-lex_start                      # E (Perl_lex_start)
 mro_get_linear_isa             # U
 mro_method_changed_in          # U
 my_dirfd                       # U
 newSV_type                     # U
 pregcomp                       # E (Perl_pregcomp)
-ptr_table_clear                # U
 ptr_table_fetch                # U
 ptr_table_free                 # U
 ptr_table_new                  # U

--- a/parts/base/5011001
+++ b/parts/base/5011001
@@ -1,6 +1,3 @@
 5.011001
 ck_warner                      # U
 ck_warner_d                    # U
-is_utf8_perl_space             # U
-is_utf8_perl_word              # U
-is_utf8_posix_digit            # U

--- a/parts/base/5011002
+++ b/parts/base/5011002
@@ -1,13 +1,2 @@
 5.011002
 PL_keyword_plugin              # E
-lex_bufutf8                    # U
-lex_discard_to                 # U
-lex_grow_linestr               # U
-lex_next_chunk                 # U
-lex_peek_unichar               # U
-lex_read_space                 # U
-lex_read_to                    # U
-lex_read_unichar               # U
-lex_stuff_pvn                  # U
-lex_stuff_sv                   # U
-lex_unstuff                    # U

--- a/parts/base/5013005
+++ b/parts/base/5013005
@@ -3,4 +3,3 @@ PL_rpeepp                      # E
 caller_cx                      # U
 isOCTAL                        # U
 lex_stuff_pvs                  # U
-parse_fullstmt                 # U

--- a/parts/base/5013006
+++ b/parts/base/5013006
@@ -7,7 +7,6 @@ ck_entersub_args_proto_or_list # U
 cv_get_call_checker            # E
 cv_set_call_checker            # E
 isWORDCHAR                     # U
-lex_stuff_pv                   # U
 mg_free_type                   # U
 newSVpv_share                  # U
 op_append_elem                 # U
@@ -15,7 +14,6 @@ op_append_list                 # U
 op_contextualize               # U
 op_linklist                    # U
 op_prepend_elem                # U
-parse_stmtseq                  # U
 rv2cv_op_cv                    # U
 savesharedpvs                  # U
 savesharedsvpv                 # U

--- a/parts/base/5013007
+++ b/parts/base/5013007
@@ -29,8 +29,3 @@ custom_op_register             # E
 custom_op_xop                  # E
 newFOROP                       # A
 newWHILEOP                     # A
-op_lvalue                      # U
-op_scope                       # U
-parse_barestmt                 # U
-parse_block                    # U
-parse_label                    # U

--- a/parts/base/5013008
+++ b/parts/base/5013008
@@ -1,8 +1,4 @@
 5.013008
 foldEQ_latin1                  # U
 mg_findext                     # U
-parse_arithexpr                # U
-parse_fullexpr                 # U
-parse_listexpr                 # U
-parse_termexpr                 # U
 sv_unmagicext                  # U

--- a/parts/base/5013010
+++ b/parts/base/5013010
@@ -1,4 +1,1 @@
 5.013010
-foldEQ_utf8_flags              # U
-is_utf8_xidcont                # U
-is_utf8_xidfirst               # U

--- a/parts/base/5014000
+++ b/parts/base/5014000
@@ -1,2 +1,1 @@
 5.014000
-_to_uni_fold_flags             # U

--- a/parts/base/5015001
+++ b/parts/base/5015001
@@ -1,6 +1,4 @@
 5.015001
-cop_fetch_label                # U
-cop_store_label                # U
 pad_add_name_pv                # U
 pad_add_name_pvn               # U
 pad_add_name_pvs               # U

--- a/parts/base/5015004
+++ b/parts/base/5015004
@@ -12,9 +12,6 @@ gv_fetchmeth_pvn               # U
 gv_fetchmeth_pvn_autoload      # U
 gv_fetchmeth_sv                # U
 gv_fetchmeth_sv_autoload       # U
-gv_fetchmethod_pv_flags        # U
-gv_fetchmethod_pvn_flags       # U
-gv_fetchmethod_sv_flags        # U
 gv_init_pv                     # U
 gv_init_pvn                    # U
 gv_init_sv                     # U

--- a/parts/base/5015009
+++ b/parts/base/5015009
@@ -1,5 +1,2 @@
 5.015009
 utf8_to_uvchr_buf              # U
-utf8_to_uvuni_buf              # U
-valid_utf8_to_uvchr            # U
-valid_utf8_to_uvuni            # U

--- a/parts/base/5017002
+++ b/parts/base/5017002
@@ -1,7 +1,4 @@
 5.017002
-is_uni_blank                   # U
-is_uni_blank_lc                # U
-is_utf8_blank                  # U
 sv_copypv_flags                # U
 sv_copypv_nomg                 # U
 sv_vcatpvfn_flags              # U

--- a/parts/base/5017007
+++ b/parts/base/5017007
@@ -1,7 +1,2 @@
 5.017007
 SvREFCNT_dec_NN                # U
-_is_uni_perl_idstart           # U
-_is_utf8_perl_idstart          # U
-is_uni_alnumc                  # U
-is_uni_alnumc_lc               # U
-is_utf8_alnumc                 # U

--- a/parts/base/5017008
+++ b/parts/base/5017008
@@ -1,8 +1,3 @@
 5.017008
-_is_uni_FOO                    # U
-_is_uni_perl_idcont            # U
-_is_utf8_FOO                   # U
-_is_utf8_mark                  # U
-_is_utf8_perl_idcont           # U
 isALPHANUMERIC                 # U
 isIDCONT                       # U

--- a/parts/base/5019004
+++ b/parts/base/5019004
@@ -1,4 +1,3 @@
 5.019004
-append_utf8_from_native_byte   # U
 is_safe_syscall                # U
 uvoffuni_to_utf8_flags         # U

--- a/parts/base/5019009
+++ b/parts/base/5019009
@@ -1,5 +1,1 @@
 5.019009
-_to_utf8_fold_flags            # A
-_to_utf8_lower_flags           # A
-_to_utf8_title_flags           # A
-_to_utf8_upper_flags           # A

--- a/parts/base/5021001
+++ b/parts/base/5021001
@@ -1,13 +1,4 @@
 5.021001
-_is_in_locale_category         # U
-_is_utf8_char_slow             # U
-_is_utf8_idcont                # U
-_is_utf8_idstart               # U
-_is_utf8_xidcont               # U
-_is_utf8_xidstart              # U
-isALNUM_lazy                   # U
-isIDFIRST_lazy                 # U
 isUTF8_CHAR                    # U
 markstack_grow                 # E (Perl_markstack_grow)
-my_strerror                    # U
 PERL_UNUSED_RESULT             # added by devel/scanprov

--- a/parts/base/5021007
+++ b/parts/base/5021007
@@ -3,9 +3,4 @@ OpHAS_SIBLING                  # U
 OpSIBLING                      # U
 PadnameUTF8                    # E
 is_invariant_string            # U
-newPADNAMELIST                 # U
-newPADNAMEouter                # U
-newPADNAMEpvn                  # U
 newUNOP_AUX                    # E
-padnamelist_fetch              # U
-padnamelist_store              # U

--- a/parts/base/5021008
+++ b/parts/base/5021008
@@ -1,2 +1,1 @@
 5.021008
-sv_get_backrefs                # U

--- a/parts/base/5023008
+++ b/parts/base/5023008
@@ -1,22 +1,2 @@
 5.023008
 clear_defarray                 # U
-cx_popblock                    # U
-cx_popeval                     # U
-cx_popformat                   # U
-cx_popgiven                    # U
-cx_poploop                     # U
-cx_popsub                      # U
-cx_popsub_args                 # U
-cx_popsub_common               # U
-cx_popwhen                     # U
-cx_pushblock                   # U
-cx_pusheval                    # U
-cx_pushformat                  # U
-cx_pushgiven                   # U
-cx_pushloop_for                # U
-cx_pushloop_plain              # U
-cx_pushsub                     # U
-cx_pushwhen                    # U
-cx_topblock                    # U
-leave_adjust_stacks            # U
-savetmps                       # U

--- a/parts/inc/cop
+++ b/parts/inc/cop
@@ -182,7 +182,7 @@ print "# $file\n";
 ok($file =~ /cop/i);
 
 BEGIN {
-  if ($] < 5.006000) {
+  if ("$]" < 5.006000) {
     # Skip
     for (1..28) {
       ok(1, 1);

--- a/parts/inc/magic
+++ b/parts/inc/magic
@@ -17,69 +17,10 @@ sv_unmagicext
 __UNDEFINED__
 /sv_\w+_mg/
 sv_magic_portable
-MUTABLE_PTR
-MUTABLE_SV
 
 =implementation
 
 __UNDEFINED__  SvGETMAGIC(x) STMT_START { if (SvGMAGICAL(x)) mg_get(x); } STMT_END
-
-/* Some random bits for sv_unmagicext. These should probably be pulled in for
-   real and organized at some point */
-
-__UNDEFINED__  HEf_SVKEY   -2
-
-#ifndef MUTABLE_PTR
-#if defined(__GNUC__) && !defined(PERL_GCC_BRACE_GROUPS_FORBIDDEN)
-#  define MUTABLE_PTR(p) ({ void *_p = (p); _p; })
-#else
-#  define MUTABLE_PTR(p) ((void *) (p))
-#endif
-#endif
-
-__UNDEFINED__ MUTABLE_SV(p)   ((SV *)MUTABLE_PTR(p))
-
-/* end of random bits */
-
-__UNDEFINED__  PERL_MAGIC_sv              '\0'
-__UNDEFINED__  PERL_MAGIC_overload        'A'
-__UNDEFINED__  PERL_MAGIC_overload_elem   'a'
-__UNDEFINED__  PERL_MAGIC_overload_table  'c'
-__UNDEFINED__  PERL_MAGIC_bm              'B'
-__UNDEFINED__  PERL_MAGIC_regdata         'D'
-__UNDEFINED__  PERL_MAGIC_regdatum        'd'
-__UNDEFINED__  PERL_MAGIC_env             'E'
-__UNDEFINED__  PERL_MAGIC_envelem         'e'
-__UNDEFINED__  PERL_MAGIC_fm              'f'
-__UNDEFINED__  PERL_MAGIC_regex_global    'g'
-__UNDEFINED__  PERL_MAGIC_isa             'I'
-__UNDEFINED__  PERL_MAGIC_isaelem         'i'
-__UNDEFINED__  PERL_MAGIC_nkeys           'k'
-__UNDEFINED__  PERL_MAGIC_dbfile          'L'
-__UNDEFINED__  PERL_MAGIC_dbline          'l'
-__UNDEFINED__  PERL_MAGIC_mutex           'm'
-__UNDEFINED__  PERL_MAGIC_shared          'N'
-__UNDEFINED__  PERL_MAGIC_shared_scalar   'n'
-__UNDEFINED__  PERL_MAGIC_collxfrm        'o'
-__UNDEFINED__  PERL_MAGIC_tied            'P'
-__UNDEFINED__  PERL_MAGIC_tiedelem        'p'
-__UNDEFINED__  PERL_MAGIC_tiedscalar      'q'
-__UNDEFINED__  PERL_MAGIC_qr              'r'
-__UNDEFINED__  PERL_MAGIC_sig             'S'
-__UNDEFINED__  PERL_MAGIC_sigelem         's'
-__UNDEFINED__  PERL_MAGIC_taint           't'
-__UNDEFINED__  PERL_MAGIC_uvar            'U'
-__UNDEFINED__  PERL_MAGIC_uvar_elem       'u'
-__UNDEFINED__  PERL_MAGIC_vstring         'V'
-__UNDEFINED__  PERL_MAGIC_vec             'v'
-__UNDEFINED__  PERL_MAGIC_utf8            'w'
-__UNDEFINED__  PERL_MAGIC_substr          'x'
-__UNDEFINED__  PERL_MAGIC_defelem         'y'
-__UNDEFINED__  PERL_MAGIC_glob            '*'
-__UNDEFINED__  PERL_MAGIC_arylen          '#'
-__UNDEFINED__  PERL_MAGIC_pos             '.'
-__UNDEFINED__  PERL_MAGIC_backref         '<'
-__UNDEFINED__  PERL_MAGIC_ext             '~'
 
 /* That's the best we can do... */
 __UNDEFINED__  sv_catpvn_nomg     sv_catpvn

--- a/parts/inc/magic
+++ b/parts/inc/magic
@@ -545,8 +545,8 @@ ok($h{sv}, 'Perl');
 
 # v1 is treated as a bareword in older perls...
 my $ver = do { local $SIG{'__WARN__'} = sub {}; eval qq[v1.2.0] };
-ok($] < 5.009 || $@ eq '');
-ok($] < 5.009 || Devel::PPPort::SvVSTRING_mg($ver));
+ok("$]" < 5.009 || $@ eq '');
+ok("$]" < 5.009 || Devel::PPPort::SvVSTRING_mg($ver));
 ok(!Devel::PPPort::SvVSTRING_mg(4711));
 
 my $foo = 'bar';

--- a/parts/inc/magic_defs
+++ b/parts/inc/magic_defs
@@ -1,0 +1,56 @@
+################################################################################
+##
+##  Version 3.x, Copyright (C) 2004-2013, Marcus Holland-Moritz.
+##  Version 2.x, Copyright (C) 2001, Paul Marquess.
+##  Version 1.x, Copyright (C) 1999, Kenneth Albanowski.
+##
+##  This program is free software; you can redistribute it and/or
+##  modify it under the same terms as Perl itself.
+##
+################################################################################
+
+=provides
+
+__UNDEFINED__
+
+=implementation
+
+__UNDEFINED__  PERL_MAGIC_sv              '\0'
+__UNDEFINED__  PERL_MAGIC_overload        'A'
+__UNDEFINED__  PERL_MAGIC_overload_elem   'a'
+__UNDEFINED__  PERL_MAGIC_overload_table  'c'
+__UNDEFINED__  PERL_MAGIC_bm              'B'
+__UNDEFINED__  PERL_MAGIC_regdata         'D'
+__UNDEFINED__  PERL_MAGIC_regdatum        'd'
+__UNDEFINED__  PERL_MAGIC_env             'E'
+__UNDEFINED__  PERL_MAGIC_envelem         'e'
+__UNDEFINED__  PERL_MAGIC_fm              'f'
+__UNDEFINED__  PERL_MAGIC_regex_global    'g'
+__UNDEFINED__  PERL_MAGIC_isa             'I'
+__UNDEFINED__  PERL_MAGIC_isaelem         'i'
+__UNDEFINED__  PERL_MAGIC_nkeys           'k'
+__UNDEFINED__  PERL_MAGIC_dbfile          'L'
+__UNDEFINED__  PERL_MAGIC_dbline          'l'
+__UNDEFINED__  PERL_MAGIC_mutex           'm'
+__UNDEFINED__  PERL_MAGIC_shared          'N'
+__UNDEFINED__  PERL_MAGIC_shared_scalar   'n'
+__UNDEFINED__  PERL_MAGIC_collxfrm        'o'
+__UNDEFINED__  PERL_MAGIC_tied            'P'
+__UNDEFINED__  PERL_MAGIC_tiedelem        'p'
+__UNDEFINED__  PERL_MAGIC_tiedscalar      'q'
+__UNDEFINED__  PERL_MAGIC_qr              'r'
+__UNDEFINED__  PERL_MAGIC_sig             'S'
+__UNDEFINED__  PERL_MAGIC_sigelem         's'
+__UNDEFINED__  PERL_MAGIC_taint           't'
+__UNDEFINED__  PERL_MAGIC_uvar            'U'
+__UNDEFINED__  PERL_MAGIC_uvar_elem       'u'
+__UNDEFINED__  PERL_MAGIC_vstring         'V'
+__UNDEFINED__  PERL_MAGIC_vec             'v'
+__UNDEFINED__  PERL_MAGIC_utf8            'w'
+__UNDEFINED__  PERL_MAGIC_substr          'x'
+__UNDEFINED__  PERL_MAGIC_defelem         'y'
+__UNDEFINED__  PERL_MAGIC_glob            '*'
+__UNDEFINED__  PERL_MAGIC_arylen          '#'
+__UNDEFINED__  PERL_MAGIC_pos             '.'
+__UNDEFINED__  PERL_MAGIC_backref         '<'
+__UNDEFINED__  PERL_MAGIC_ext             '~'

--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -302,17 +302,98 @@ typedef OP* (CPERLscope(*Perl_check_t)) (pTHX_ OP*);
 
 #endif
 
-__UNDEFINED__ isPSXSPC(c)       (isSPACE(c) || (c) == '\v')
-__UNDEFINED__ isBLANK(c)        ((c) == ' ' || (c) == '\t')
+# ifdef HAS_QUAD
+#  ifdef U64TYPE
+__UNDEFINED__ WIDEST_UTYPE U64TYPE
+#  else
+__UNDEFINED__ WIDEST_UTYPE Quad_t
+#  endif
+# else
+__UNDEFINED__ WIDEST_UTYPE U32
+# endif
+
 #ifdef EBCDIC
-__UNDEFINED__ isALNUMC(c)       isalnum(c)
-__UNDEFINED__ isASCII(c)        isascii(c)
-__UNDEFINED__ isCNTRL(c)        iscntrl(c)
-__UNDEFINED__ isGRAPH(c)        isgraph(c)
-__UNDEFINED__ isPRINT(c)        isprint(c)
-__UNDEFINED__ isPUNCT(c)        ispunct(c)
-__UNDEFINED__ isXDIGIT(c)       isxdigit(c)
-#else
+
+/* This is the first version where these macros are fully correct.  Relying on
+ * the C library functions, as earlier releases did, causes problems with
+ * locales */
+# if { VERSION < 5.22.0 }
+#  undef isALNUM
+#  undef isALNUMC
+#  undef isALPHA
+#  undef isALPHANUMERIC
+#  undef isASCII
+#  undef isBLANK
+#  undef isCNTRL
+#  undef isDIGIT
+#  undef isGRAPH
+#  undef isIDCONT
+#  undef isIDFIRST
+#  undef isLOWER
+#  undef isOCTAL
+#  undef isPRINT
+#  undef isPSXSPC
+#  undef isPUNCT
+#  undef isSPACE
+#  undef isUPPER
+#  undef isWORDCHAR
+#  undef isXDIGIT
+# endif
+
+__UNDEFINED__ isASCII(c)    (isCNTRL(c) || isPRINT(c))
+
+        /* The below is accurate for all EBCDIC code pages supported by
+         * all the versions of Perl overridden by this */
+__UNDEFINED__ isCNTRL(c)    (    (c) == '\0' || (c) == '\a' || (c) == '\b'      \
+                             ||  (c) == '\f' || (c) == '\n' || (c) == '\r'      \
+                             ||  (c) == '\t' || (c) == '\v'                     \
+                             || ((c) <= 3 && (c) >= 1) /* SOH, STX, ETX */      \
+                             ||  (c) == 7    /* U+7F DEL */                     \
+                             || ((c) <= 0x13 && (c) >= 0x0E) /* SO, SI */       \
+                                                      /* DLE, DC[1-3] */        \
+                             ||  (c) == 0x18 /* U+18 CAN */                     \
+                             ||  (c) == 0x19 /* U+19 EOM */                     \
+                             || ((c) <= 0x1F && (c) >= 0x1C) /* [FGRU]S */      \
+                             ||  (c) == 0x26 /* U+17 ETB */                     \
+                             ||  (c) == 0x27 /* U+1B ESC */                     \
+                             ||  (c) == 0x2D /* U+05 ENQ */                     \
+                             ||  (c) == 0x2E /* U+06 ACK */                     \
+                             ||  (c) == 0x32 /* U+16 SYN */                     \
+                             ||  (c) == 0x37 /* U+04 EOT */                     \
+                             ||  (c) == 0x3C /* U+14 DC4 */                     \
+                             ||  (c) == 0x3D /* U+15 NAK */                     \
+                             ||  (c) == 0x3F /* U+1A SUB */                     \
+                            )
+/* The ordering of the tests in this and isUPPER are to exclude most characters
+ * early */
+__UNDEFINED__ isLOWER(c)    (        (c) >= 'a' && (c) <= 'z'                   \
+                             &&  (   (c) <= 'i'                                 \
+                                 || ((c) >= 'j' && (c) <= 'r')                  \
+                                 ||  (c) >= 's'))
+__UNDEFINED__ isUPPER(c)    (        (c) >= 'A' && (c) <= 'Z'                   \
+                             && (    (c) <= 'I'                                 \
+                                 || ((c) >= 'J' && (c) <= 'R')                  \
+                                 ||  (c) >= 'S'))
+
+#else   /* Above is EBCDIC; below is ASCII */
+
+# if { VERSION < 5.4.0 }
+/* The implementation of these in older perl versions can give wrong results if
+ * the C program locale is set to other than the C locale */
+#  undef isALNUM
+#  undef isALPHA
+#  undef isDIGIT
+#  undef isIDFIRST
+#  undef isLOWER
+#  undef isUPPER
+# endif
+
+# if { VERSION < 5.8.0 }
+/* Hint: isCNTRL
+ * Earlier perls omitted DEL */
+#  undef isCNTRL
+# endif
+
 # if { VERSION < 5.10.0 }
 /* Hint: isPRINT
  * The implementation in older perl versions includes all of the
@@ -322,24 +403,75 @@ __UNDEFINED__ isXDIGIT(c)       isxdigit(c)
 #  undef isPRINT
 # endif
 
-#ifdef HAS_QUAD
-# ifdef U64TYPE
-#  define WIDEST_UTYPE U64TYPE
-# else
-#  define WIDEST_UTYPE Quad_t
+# if { VERSION < 5.14.0 }
+/* Hint: isASCII
+ * The implementation in older perl versions always returned true if the
+ * parameter was a signed char
+ */
+#  undef isASCII
 # endif
-#else
-# define WIDEST_UTYPE U32
-#endif
 
-__UNDEFINED__ isALNUMC(c)       (isALPHA(c) || isDIGIT(c))
+# if { VERSION < 5.20.0 }
+/* Hint: isSPACE
+ * The implementation in older perl versions didn't include \v */
+#  undef isSPACE
+# endif
+
 __UNDEFINED__ isASCII(c)        ((WIDEST_UTYPE) (c) <= 127)
 __UNDEFINED__ isCNTRL(c)        ((WIDEST_UTYPE) (c) < ' ' || (c) == 127)
-__UNDEFINED__ isGRAPH(c)        (isALNUM(c) || isPUNCT(c))
-__UNDEFINED__ isPRINT(c)        (((c) >= 32 && (c) < 127))
-__UNDEFINED__ isPUNCT(c)        (((c) >= 33 && (c) <= 47) || ((c) >= 58 && (c) <= 64)  || ((c) >= 91 && (c) <= 96) || ((c) >= 123 && (c) <= 126))
-__UNDEFINED__ isXDIGIT(c)       (isDIGIT(c) || ((c) >= 'a' && (c) <= 'f') || ((c) >= 'A' && (c) <= 'F'))
-#endif
+__UNDEFINED__ isLOWER(c)        ((c) >= 'a' && (c) <= 'z')
+__UNDEFINED__ isUPPER(c)        ((c) <= 'Z' && (c) >= 'A')
+#endif /* Below are definitions common to EBCDIC and ASCII */
+
+__UNDEFINED__ isALNUM(c)        isWORDCHAR(c)
+__UNDEFINED__ isALNUMC(c)       isALPHANUMERIC(c) 
+__UNDEFINED__ isALPHA(c)        (isUPPER(c) || isLOWER(c))
+__UNDEFINED__ isALPHANUMERIC(c) (isALPHA(c) || isDIGIT(c))
+__UNDEFINED__ isBLANK(c)        ((c) == ' ' || (c) == '\t')
+__UNDEFINED__ isDIGIT(c)        ((c) <= '9' && (c) >= '0')
+__UNDEFINED__ isGRAPH(c)        (isWORDCHAR(c) || isPUNCT(c))
+__UNDEFINED__ isIDCONT(c)       isWORDCHAR(c)
+__UNDEFINED__ isIDFIRST(c)      (isALPHA(c) || (c) == '_')
+__UNDEFINED__ isOCTAL(c)        (((WIDEST_UTYPE)((c)) & ~7) == '0')
+__UNDEFINED__ isPRINT(c)        (isGRAPH(c) || (c) == ' ')
+__UNDEFINED__ isPSXSPC(c)       isSPACE(c)
+__UNDEFINED__ isPUNCT(c)    (   (c) == '-' || (c) == '!' || (c) == '"'          \
+                             || (c) == '#' || (c) == '$' || (c) == '%'          \
+                             || (c) == '&' || (c) == '\'' || (c) == '('         \
+                             || (c) == ')' || (c) == '*' || (c) == '+'          \
+                             || (c) == ',' || (c) == '.' || (c) == '/'          \
+                             || (c) == ':' || (c) == ';' || (c) == '<'          \
+                             || (c) == '=' || (c) == '>' || (c) == '?'          \
+                             || (c) == '@' || (c) == '[' || (c) == '\\'         \
+                             || (c) == ']' || (c) == '^' || (c) == '_'          \
+                             || (c) == '`' || (c) == '{' || (c) == '|'          \
+                             || (c) == '}' || (c) == '~')
+__UNDEFINED__ isSPACE(c)        (   isBLANK(c) || (c) == '\n' || (c) == '\r'    \
+                                 || (c) == '\v' || (c) == '\f')
+__UNDEFINED__ isWORDCHAR(c)     (isALPHANUMERIC(c) || (c) == '_')
+__UNDEFINED__ isXDIGIT(c)       (   isDIGIT(c)                                  \
+                                 || ((c) >= 'a' && (c) <= 'f')                  \
+                                 || ((c) >= 'A' && (c) <= 'F'))
+
+__UNDEFINED__ isALNUM_A         isALNUM
+__UNDEFINED__ isALNUMC_A        isALNUMC
+__UNDEFINED__ isALPHA_A         isALPHA
+__UNDEFINED__ isALPHANUMERIC_A  isALPHANUMERIC
+__UNDEFINED__ isASCII_A         isASCII
+__UNDEFINED__ isBLANK_A         isBLANK
+__UNDEFINED__ isCNTRL_A         isCNTRL
+__UNDEFINED__ isDIGIT_A         isDIGIT
+__UNDEFINED__ isGRAPH_A         isGRAPH
+__UNDEFINED__ isIDCONT_A        isIDCONT
+__UNDEFINED__ isIDFIRST_A       isIDFIRST
+__UNDEFINED__ isLOWER_A         isLOWER
+__UNDEFINED__ isOCTAL_A         isOCTAL
+__UNDEFINED__ isPRINT_A         isPRINT
+__UNDEFINED__ isPSXSPC_A        isPSXSPC
+__UNDEFINED__ isPUNCT_A         isPUNCT
+__UNDEFINED__ isSPACE_A         isSPACE
+__UNDEFINED__ isUPPER_A         isUPPER
+__UNDEFINED__ isWORDCHAR_A      isWORDCHAR
 
 /* Until we figure out how to support this in older perls... */
 #if { VERSION >= 5.8.0 }

--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -43,17 +43,16 @@ C_ARRAY_LENGTH
 C_ARRAY_END
 SvRX
 SvRXOK
-PERL_MAGIC_qr
 cBOOL
 OpHAS_SIBLING
 OpSIBLING
 OpMORESIB_set
 OpLASTSIB_set
 OpMAYBESIB_set
+MUTABLE_PTR
+MUTABLE_SV
 
 =implementation
-
-__UNDEFINED__ PERL_MAGIC_qr             'r'
 
 __UNDEFINED__ cBOOL(cbool) ((cbool) ? (bool)1 : (bool)0)
 __UNDEFINED__ OpHAS_SIBLING(o)      (cBOOL((o)->op_sibling))
@@ -61,6 +60,7 @@ __UNDEFINED__ OpSIBLING(o)          (0 + (o)->op_sibling)
 __UNDEFINED__ OpMORESIB_set(o, sib) ((o)->op_sibling = (sib))
 __UNDEFINED__ OpLASTSIB_set(o, parent) ((o)->op_sibling = NULL)
 __UNDEFINED__ OpMAYBESIB_set(o, sib, parent) ((o)->op_sibling = (sib))
+__UNDEFINED__ HEf_SVKEY   -2
 
 #ifndef SvRX
 #if { NEED SvRX }
@@ -352,6 +352,16 @@ __UNDEFINED__ HeUTF8(he)        ((HeKLEN(he) == HEf_SVKEY) ?            \
 
 __UNDEFINED__ C_ARRAY_LENGTH(a)		(sizeof(a)/sizeof((a)[0]))
 __UNDEFINED__ C_ARRAY_END(a)		((a) + C_ARRAY_LENGTH(a))
+
+#ifndef MUTABLE_PTR
+#if defined(__GNUC__) && !defined(PERL_GCC_BRACE_GROUPS_FORBIDDEN)
+#  define MUTABLE_PTR(p) ({ void *_p = (p); _p; })
+#else
+#  define MUTABLE_PTR(p) ((void *) (p))
+#endif
+#endif
+
+__UNDEFINED__ MUTABLE_SV(p)   ((SV *)MUTABLE_PTR(p))
 
 =xsmisc
 

--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -698,7 +698,7 @@ $_ = "Fred";
 ok(&Devel::PPPort::DEFSV(), "Fred");
 ok(&Devel::PPPort::UNDERBAR(), "Fred");
 
-if ($] >= 5.009002 && $] < 5.023 && $] < 5.023004) {
+if ("$]" >= 5.009002 && "$]" < 5.023 && "$]" < 5.023004) {
   eval q{
     no warnings "deprecated";
     no if $^V > v5.17.9, warnings => "experimental::lexical_topic";
@@ -761,8 +761,8 @@ ok(join(':', Devel::PPPort::xsreturn(1)), 'test1:test2');
 ok(Devel::PPPort::PERL_ABS(42), 42);
 ok(Devel::PPPort::PERL_ABS(-13), 13);
 
-ok(Devel::PPPort::SVf(42), $] >= 5.004 ? '[42]' : '42');
-ok(Devel::PPPort::SVf('abc'), $] >= 5.004 ? '[abc]' : 'abc');
+ok(Devel::PPPort::SVf(42), "$]" >= 5.004 ? '[42]' : '42');
+ok(Devel::PPPort::SVf('abc'), "$]" >= 5.004 ? '[abc]' : 'abc');
 
 ok(&Devel::PPPort::Perl_ppaddr_t("FOO"), "foo");
 
@@ -770,7 +770,7 @@ ok(&Devel::PPPort::ptrtests(), 63);
 
 ok(&Devel::PPPort::OpSIBLING_tests(), 0);
 
-if ($] >= 5.009000) {
+if ("$]" >= 5.009000) {
   eval q{
     ok(&Devel::PPPort::check_HeUTF8("hello"), "norm");
     ok(&Devel::PPPort::check_HeUTF8("\N{U+263a}"), "utf8");
@@ -787,7 +787,7 @@ ok($r[1], "13");
 ok(!Devel::PPPort::SvRXOK(""));
 ok(!Devel::PPPort::SvRXOK(bless [], "Regexp"));
 
-if ($] < 5.005) {
+if ("$]" < 5.005) {
         skip 'no qr// objects in this perl', 0;
         skip 'no qr// objects in this perl', 0;
 } else {

--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -424,7 +424,7 @@ __UNDEFINED__ isUPPER(c)        ((c) <= 'Z' && (c) >= 'A')
 #endif /* Below are definitions common to EBCDIC and ASCII */
 
 __UNDEFINED__ isALNUM(c)        isWORDCHAR(c)
-__UNDEFINED__ isALNUMC(c)       isALPHANUMERIC(c) 
+__UNDEFINED__ isALNUMC(c)       isALPHANUMERIC(c)
 __UNDEFINED__ isALPHA(c)        (isUPPER(c) || isLOWER(c))
 __UNDEFINED__ isALPHANUMERIC(c) (isALPHA(c) || isDIGIT(c))
 __UNDEFINED__ isBLANK(c)        ((c) == ' ' || (c) == '\t')

--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -819,7 +819,273 @@ check_c_array()
                 mXPUSHi(C_ARRAY_LENGTH(x));  /* 4 */
                 mXPUSHi(*(C_ARRAY_END(x)-1)); /* 13 */
 
-=tests plan => 48
+bool
+test_isBLANK(UV ord)
+    CODE:
+        RETVAL = isBLANK(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isBLANK_A(UV ord)
+    CODE:
+        RETVAL = isBLANK_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isUPPER(UV ord)
+    CODE:
+        RETVAL = isUPPER(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isUPPER_A(UV ord)
+    CODE:
+        RETVAL = isUPPER_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isLOWER(UV ord)
+    CODE:
+        RETVAL = isLOWER(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isLOWER_A(UV ord)
+    CODE:
+        RETVAL = isLOWER_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isALPHA(UV ord)
+    CODE:
+        RETVAL = isALPHA(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isALPHA_A(UV ord)
+    CODE:
+        RETVAL = isALPHA_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isWORDCHAR(UV ord)
+    CODE:
+        RETVAL = isWORDCHAR(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isWORDCHAR_A(UV ord)
+    CODE:
+        RETVAL = isWORDCHAR_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isALPHANUMERIC(UV ord)
+    CODE:
+        RETVAL = isALPHANUMERIC(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isALPHANUMERIC_A(UV ord)
+    CODE:
+        RETVAL = isALPHANUMERIC_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isALNUM(UV ord)
+    CODE:
+        RETVAL = isALNUM(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isALNUM_A(UV ord)
+    CODE:
+        RETVAL = isALNUM_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isDIGIT(UV ord)
+    CODE:
+        RETVAL = isDIGIT(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isDIGIT_A(UV ord)
+    CODE:
+        RETVAL = isDIGIT_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isOCTAL(UV ord)
+    CODE:
+        RETVAL = isOCTAL(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isOCTAL_A(UV ord)
+    CODE:
+        RETVAL = isOCTAL_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isIDFIRST(UV ord)
+    CODE:
+        RETVAL = isIDFIRST(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isIDFIRST_A(UV ord)
+    CODE:
+        RETVAL = isIDFIRST_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isIDCONT(UV ord)
+    CODE:
+        RETVAL = isIDCONT(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isIDCONT_A(UV ord)
+    CODE:
+        RETVAL = isIDCONT_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isSPACE(UV ord)
+    CODE:
+        RETVAL = isSPACE(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isSPACE_A(UV ord)
+    CODE:
+        RETVAL = isSPACE_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isASCII(UV ord)
+    CODE:
+        RETVAL = isASCII(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isASCII_A(UV ord)
+    CODE:
+        RETVAL = isASCII_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isCNTRL(UV ord)
+    CODE:
+        RETVAL = isCNTRL(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isCNTRL_A(UV ord)
+    CODE:
+        RETVAL = isCNTRL_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isPRINT(UV ord)
+    CODE:
+        RETVAL = isPRINT(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isPRINT_A(UV ord)
+    CODE:
+        RETVAL = isPRINT_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isGRAPH(UV ord)
+    CODE:
+        RETVAL = isGRAPH(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isGRAPH_A(UV ord)
+    CODE:
+        RETVAL = isGRAPH_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isPUNCT(UV ord)
+    CODE:
+        RETVAL = isPUNCT(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isPUNCT_A(UV ord)
+    CODE:
+        RETVAL = isPUNCT_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isXDIGIT(UV ord)
+    CODE:
+        RETVAL = isXDIGIT(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isXDIGIT_A(UV ord)
+    CODE:
+        RETVAL = isXDIGIT_A(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isPSXSPC(UV ord)
+    CODE:
+        RETVAL = isPSXSPC(ord);
+    OUTPUT:
+        RETVAL
+
+bool
+test_isPSXSPC_A(UV ord)
+    CODE:
+        RETVAL = isPSXSPC_A(ord);
+    OUTPUT:
+        RETVAL
+
+=tests plan => 126
 
 use vars qw($my_sv @my_av %my_hv);
 
@@ -927,3 +1193,129 @@ if ("$]" < 5.005) {
         ok(Devel::PPPort::SvRXOK($qr));
         ok(Devel::PPPort::SvRXOK(bless $qr, "Surprise"));
 }
+
+ok(  Devel::PPPort::test_isBLANK(ord(" ")));
+ok(! Devel::PPPort::test_isBLANK(ord("\n")));
+
+ok(  Devel::PPPort::test_isBLANK_A(ord("\t")));
+ok(! Devel::PPPort::test_isBLANK_A(ord("\r")));
+
+ok(  Devel::PPPort::test_isUPPER(ord("A")));
+ok(! Devel::PPPort::test_isUPPER(ord("a")));
+
+ok(  Devel::PPPort::test_isUPPER_A(ord("Z")));
+
+# One of these two is uppercase in EBCDIC; the other in Latin1, but neither are
+# ASCII uppercase.
+ok(! Devel::PPPort::test_isUPPER_A(ord(0xDC)));
+ok(! Devel::PPPort::test_isUPPER_A(ord(0xFC)));
+
+ok(  Devel::PPPort::test_isLOWER(ord("b")));
+ok(! Devel::PPPort::test_isLOWER(ord("B")));
+
+ok(  Devel::PPPort::test_isLOWER_A(ord("y")));
+
+# One of these two is lowercase in EBCDIC; the other in Latin1, but neither are
+# ASCII lowercase.
+ok(! Devel::PPPort::test_isLOWER_A(ord(0xDC)));
+ok(! Devel::PPPort::test_isLOWER_A(ord(0xFC)));
+
+ok(  Devel::PPPort::test_isALPHA(ord("C")));
+ok(! Devel::PPPort::test_isALPHA(ord("1")));
+
+ok(  Devel::PPPort::test_isALPHA_A(ord("x")));
+ok(! Devel::PPPort::test_isALPHA_A(0xDC));
+
+ok(  Devel::PPPort::test_isWORDCHAR(ord("_")));
+ok(! Devel::PPPort::test_isWORDCHAR(ord("@")));
+
+ok(  Devel::PPPort::test_isWORDCHAR_A(ord("2")));
+ok(! Devel::PPPort::test_isWORDCHAR_A(0xFC));
+
+ok(  Devel::PPPort::test_isALPHANUMERIC(ord("4")));
+ok(! Devel::PPPort::test_isALPHANUMERIC(ord("_")));
+
+ok(  Devel::PPPort::test_isALPHANUMERIC_A(ord("l")));
+ok(! Devel::PPPort::test_isALPHANUMERIC_A(0xDC));
+
+ok(  Devel::PPPort::test_isALNUM(ord("c")));
+ok(! Devel::PPPort::test_isALNUM(ord("}")));
+
+ok(  Devel::PPPort::test_isALNUM_A(ord("5")));
+ok(! Devel::PPPort::test_isALNUM_A(0xFC));
+
+ok(  Devel::PPPort::test_isDIGIT(ord("6")));
+ok(! Devel::PPPort::test_isDIGIT(ord("_")));
+
+ok(  Devel::PPPort::test_isDIGIT_A(ord("7")));
+ok(! Devel::PPPort::test_isDIGIT_A(0xDC));
+
+ok(  Devel::PPPort::test_isOCTAL(ord("7")));
+ok(! Devel::PPPort::test_isOCTAL(ord("8")));
+
+ok(  Devel::PPPort::test_isOCTAL_A(ord("0")));
+ok(! Devel::PPPort::test_isOCTAL_A(ord("9")));
+
+ok(  Devel::PPPort::test_isIDFIRST(ord("D")));
+ok(! Devel::PPPort::test_isIDFIRST(ord("1")));
+
+ok(  Devel::PPPort::test_isIDFIRST_A(ord("_")));
+ok(! Devel::PPPort::test_isIDFIRST_A(0xFC));
+
+ok(  Devel::PPPort::test_isIDCONT(ord("e")));
+ok(! Devel::PPPort::test_isIDCONT(ord("@")));
+
+ok(  Devel::PPPort::test_isIDCONT_A(ord("2")));
+ok(! Devel::PPPort::test_isIDCONT_A(0xDC));
+
+ok(  Devel::PPPort::test_isSPACE(ord(" ")));
+ok(! Devel::PPPort::test_isSPACE(ord("_")));
+
+ok(  Devel::PPPort::test_isSPACE_A(ord("\cK")));
+ok(! Devel::PPPort::test_isSPACE_A(ord("F")));
+
+# This stresses the edge for ASCII machines, but happens to work on EBCDIC as
+# well
+ok(  Devel::PPPort::test_isASCII(0x7F));
+ok(! Devel::PPPort::test_isASCII(0x80));
+
+ok(  Devel::PPPort::test_isASCII_A(ord("9")));
+
+# B6 is the PARAGRAPH SIGN in ASCII and EBCDIC
+ok(! Devel::PPPort::test_isASCII_A(0xB6));
+
+ok(  Devel::PPPort::test_isCNTRL(ord("\e")));
+ok(! Devel::PPPort::test_isCNTRL(ord(" ")));
+
+ok(  Devel::PPPort::test_isCNTRL_A(ord("\a")));
+ok(! Devel::PPPort::test_isCNTRL_A(0xB6));
+
+ok(  Devel::PPPort::test_isPRINT(ord(" ")));
+ok(! Devel::PPPort::test_isPRINT(ord("\n")));
+
+ok(  Devel::PPPort::test_isPRINT_A(ord("G")));
+ok(! Devel::PPPort::test_isPRINT_A(0xB6));
+
+ok(  Devel::PPPort::test_isGRAPH(ord("h")));
+ok(! Devel::PPPort::test_isGRAPH(ord(" ")));
+
+ok(  Devel::PPPort::test_isGRAPH_A(ord("i")));
+ok(! Devel::PPPort::test_isGRAPH_A(0xB6));
+
+ok(  Devel::PPPort::test_isPUNCT(ord("#")));
+ok(! Devel::PPPort::test_isPUNCT(ord(" ")));
+
+ok(  Devel::PPPort::test_isPUNCT_A(ord("*")));
+ok(! Devel::PPPort::test_isPUNCT_A(0xB6));
+
+ok(  Devel::PPPort::test_isXDIGIT(ord("A")));
+ok(! Devel::PPPort::test_isXDIGIT(ord("_")));
+
+ok(  Devel::PPPort::test_isXDIGIT_A(ord("9")));
+ok(! Devel::PPPort::test_isXDIGIT_A(0xDC));
+
+ok(  Devel::PPPort::test_isPSXSPC(ord(" ")));
+ok(! Devel::PPPort::test_isPSXSPC(ord("k")));
+
+ok(  Devel::PPPort::test_isPSXSPC_A(ord("\cK")));
+ok(! Devel::PPPort::test_isPSXSPC_A(0xFC));

--- a/parts/inc/newSVpv
+++ b/parts/inc/newSVpv
@@ -100,7 +100,7 @@ ok(!defined($s[4]));
 ok(@s == 1);
 ok($s[0], "test");
 
-if ($] >= 5.008001) {
+if ("$]" >= 5.008001) {
   require utf8;
   ok(utf8::is_utf8($s[0]));
 }

--- a/parts/inc/ppphbin
+++ b/parts/inc/ppphbin
@@ -16,7 +16,7 @@
 use strict;
 
 # Disable broken TRIE-optimization
-BEGIN { eval '${^RE_TRIE_MAXBUF} = -1' if $] >= 5.009004 && $] <= 5.009005 }
+BEGIN { eval '${^RE_TRIE_MAXBUF} = -1' if "$]" >= 5.009004 && "$]" <= 5.009005 }
 
 my $VERSION = __VERSION__;
 

--- a/parts/inc/pv_tools
+++ b/parts/inc/pv_tools
@@ -252,7 +252,7 @@ pv_display()
 my $uni = &Devel::PPPort::pv_escape_can_unicode();
 
 # sanity check
-ok($uni ? $] >= 5.006 : $] < 5.008);
+ok($uni ? "$]" >= 5.006 : "$]" < 5.008);
 
 my @r;
 

--- a/parts/inc/sv_xpvf
+++ b/parts/inc/sv_xpvf
@@ -290,24 +290,24 @@ tie %h, 'Tie::StdHash';
 $h{foo} = 'foo-';
 $h{bar} = '';
 
-ok(&Devel::PPPort::vnewSVpvf(), $] >= 5.004 ? 'Perl-42' : '%s-%d');
-ok(&Devel::PPPort::sv_vcatpvf('1-2-3-'), $] >= 5.004 ? '1-2-3-Perl-42' : '1-2-3-%s-%d');
-ok(&Devel::PPPort::sv_vsetpvf('1-2-3-'), $] >= 5.004 ? 'Perl-42' : '%s-%d');
+ok(&Devel::PPPort::vnewSVpvf(), "$]" >= 5.004 ? 'Perl-42' : '%s-%d');
+ok(&Devel::PPPort::sv_vcatpvf('1-2-3-'), "$]" >= 5.004 ? '1-2-3-Perl-42' : '1-2-3-%s-%d');
+ok(&Devel::PPPort::sv_vsetpvf('1-2-3-'), "$]" >= 5.004 ? 'Perl-42' : '%s-%d');
 
 &Devel::PPPort::sv_catpvf_mg($h{foo});
-ok($h{foo}, $] >= 5.004 ? 'foo-Perl-42' : 'foo-');
+ok($h{foo}, "$]" >= 5.004 ? 'foo-Perl-42' : 'foo-');
 
 &Devel::PPPort::Perl_sv_catpvf_mg($h{foo});
-ok($h{foo}, $] >= 5.004 ? 'foo-Perl-42-Perl-43' : 'foo-');
+ok($h{foo}, "$]" >= 5.004 ? 'foo-Perl-42-Perl-43' : 'foo-');
 
 &Devel::PPPort::sv_catpvf_mg_nocontext($h{foo});
-ok($h{foo}, $] >= 5.004 ? 'foo-Perl-42-Perl-43-Perl-44' : 'foo-');
+ok($h{foo}, "$]" >= 5.004 ? 'foo-Perl-42-Perl-43-Perl-44' : 'foo-');
 
 &Devel::PPPort::sv_setpvf_mg($h{bar});
-ok($h{bar}, $] >= 5.004 ? 'mhx-42' : '');
+ok($h{bar}, "$]" >= 5.004 ? 'mhx-42' : '');
 
 &Devel::PPPort::Perl_sv_setpvf_mg($h{bar});
-ok($h{bar}, $] >= 5.004 ? 'foo-43' : '');
+ok($h{bar}, "$]" >= 5.004 ? 'foo-43' : '');
 
 &Devel::PPPort::sv_setpvf_mg_nocontext($h{bar});
-ok($h{bar}, $] >= 5.004 ? 'bar-44' : '');
+ok($h{bar}, "$]" >= 5.004 ? 'bar-44' : '');

--- a/parts/inc/variables
+++ b/parts/inc/variables
@@ -441,7 +441,7 @@ ok(!&Devel::PPPort::PL_sv_no());
 ok(&Devel::PPPort::PL_na("abcd"), 4);
 ok(&Devel::PPPort::PL_Sv(), "mhx");
 ok(defined &Devel::PPPort::PL_tokenbuf());
-ok($] >= 5.009005 || &Devel::PPPort::PL_parser());
+ok("$]" >= 5.009005 || &Devel::PPPort::PL_parser());
 ok(&Devel::PPPort::PL_hexdigit() =~ /^[0-9a-zA-Z]+$/);
 ok(defined &Devel::PPPort::PL_hints());
 ok(&Devel::PPPort::PL_ppaddr("mhx"), "MHX");
@@ -457,7 +457,7 @@ for (&Devel::PPPort::other_variables()) {
     local $SIG{'__WARN__'} = sub { push @w, @_ };
     ok(&Devel::PPPort::dummy_parser_warning());
   }
-  if ($] >= 5.009005) {
+  if ("$]" >= 5.009005) {
     ok(@w >= 0);
     for (@w) {
       print "# $_";
@@ -473,11 +473,11 @@ for (&Devel::PPPort::other_variables()) {
   ok($fail, 0);
 }
 
-ok(&Devel::PPPort::no_dummy_parser_vars(1) >= ($] < 5.009005 ? 1 : 0));
+ok(&Devel::PPPort::no_dummy_parser_vars(1) >= ("$]" < 5.009005 ? 1 : 0));
 
 eval { &Devel::PPPort::no_dummy_parser_vars(0) };
 
-if ($] < 5.009005) {
+if ("$]" < 5.009005) {
   ok($@, '');
 }
 else {

--- a/parts/inc/warn
+++ b/parts/inc/warn
@@ -147,15 +147,15 @@ $SIG{'__WARN__'} = sub { $warning = $_[0] };
 
 $warning = '';
 Devel::PPPort::warner();
-ok($] >= 5.004 ? $warning =~ /^warner bar:42/ : $warning eq '');
+ok("$]" >= 5.004 ? $warning =~ /^warner bar:42/ : $warning eq '');
 
 $warning = '';
 Devel::PPPort::Perl_warner();
-ok($] >= 5.004 ? $warning =~ /^Perl_warner bar:42/ : $warning eq '');
+ok("$]" >= 5.004 ? $warning =~ /^Perl_warner bar:42/ : $warning eq '');
 
 $warning = '';
 Devel::PPPort::Perl_warner_nocontext();
-ok($] >= 5.004 ? $warning =~ /^Perl_warner_nocontext bar:42/ : $warning eq '');
+ok("$]" >= 5.004 ? $warning =~ /^Perl_warner_nocontext bar:42/ : $warning eq '');
 
 $warning = '';
 Devel::PPPort::ckWARN();
@@ -165,4 +165,4 @@ $^W = 1;
 
 $warning = '';
 Devel::PPPort::ckWARN();
-ok($] >= 5.004 ? $warning =~ /^ckWARN bar:42/ : $warning eq '');
+ok("$]" >= 5.004 ? $warning =~ /^ckWARN bar:42/ : $warning eq '');

--- a/parts/ppptools.pl
+++ b/parts/ppptools.pl
@@ -306,6 +306,7 @@ sub parse_embed
         my @e = split /\s*\|\s*/, $line;
         if( @e >= 3 ) {
           my($flags, $ret, $name, @args) = @e;
+          next if $flags =~ /[DM]/; # Skip entries marked as deprecated or unstable
           if ($name =~ /^[^\W\d]\w*$/) {
             for (@args) {
               $_ = [trim_arg($_)];

--- a/parts/todo/5005000
+++ b/parts/todo/5005000
@@ -9,7 +9,6 @@ fbm_instr                      # E (Perl_fbm_instr)
 get_op_descs                   # U
 get_op_names                   # U
 init_stacks                    # U
-mg_length                      # U
 mg_size                        # U
 newHVhv                        # U
 new_stackinfo                  # E

--- a/parts/todo/5006000
+++ b/parts/todo/5006000
@@ -46,49 +46,6 @@ dump_vindent                   # U
 get_context                    # U
 get_ppaddr                     # E
 gv_dump                        # U
-init_i18nl10n                  # U (perl_init_i18nl10n)
-init_i18nl14n                  # U (perl_init_i18nl14n)
-is_uni_alnum                   # U
-is_uni_alnum_lc                # U
-is_uni_alpha                   # U
-is_uni_alpha_lc                # U
-is_uni_ascii                   # U
-is_uni_ascii_lc                # U
-is_uni_cntrl                   # U
-is_uni_cntrl_lc                # U
-is_uni_digit                   # U
-is_uni_digit_lc                # U
-is_uni_graph                   # U
-is_uni_graph_lc                # U
-is_uni_idfirst                 # U
-is_uni_idfirst_lc              # U
-is_uni_lower                   # U
-is_uni_lower_lc                # U
-is_uni_print                   # U
-is_uni_print_lc                # U
-is_uni_punct                   # U
-is_uni_punct_lc                # U
-is_uni_space                   # U
-is_uni_space_lc                # U
-is_uni_upper                   # U
-is_uni_upper_lc                # U
-is_uni_xdigit                  # U
-is_uni_xdigit_lc               # U
-is_utf8_alnum                  # U
-is_utf8_alpha                  # U
-is_utf8_ascii                  # U
-is_utf8_char                   # U
-is_utf8_cntrl                  # U
-is_utf8_digit                  # U
-is_utf8_graph                  # U
-is_utf8_idfirst                # U
-is_utf8_lower                  # U
-is_utf8_mark                   # U
-is_utf8_print                  # U
-is_utf8_punct                  # U
-is_utf8_space                  # U
-is_utf8_upper                  # U
-is_utf8_xdigit                 # U
 magic_dump                     # U
 mess                           # E (Perl_mess)
 my_atof                        # U
@@ -97,9 +54,6 @@ newANONATTRSUB                 # U
 newATTRSUB                     # U
 newXS                          # E (Perl_newXS)
 newXSproto                     # E
-new_collate                    # U (perl_new_collate)
-new_ctype                      # U (perl_new_ctype)
-new_numeric                    # U (perl_new_numeric)
 op_dump                        # U
 perl_parse                     # E (perl_parse)
 pmop_dump                      # U
@@ -136,13 +90,7 @@ sv_pvutf8                      # U
 sv_pvutf8n                     # U
 sv_pvutf8n_force               # U
 sv_rvweaken                    # U
-sv_utf8_decode                 # U
-sv_utf8_downgrade              # U
 sv_utf8_encode                 # U
-swash_init                     # U
-to_uni_lower_lc                # U
-to_uni_title_lc                # U
-to_uni_upper_lc                # U
 utf8_distance                  # U
 utf8_hop                       # U
 vcroak                         # U

--- a/parts/todo/5006001
+++ b/parts/todo/5006001
@@ -1,11 +1,8 @@
 5.006001
 SvGAMAGIC                      # U
-apply_attrs_string             # U
-bytes_to_utf8                  # U
 gv_efullname4                  # U
 gv_fullname4                   # U
 is_utf8_string                 # U
 save_generic_pvref             # U
 utf16_to_utf8                  # E (Perl_utf16_to_utf8)
 utf16_to_utf8_reversed         # E (Perl_utf16_to_utf8_reversed)
-utf8_to_bytes                  # U

--- a/parts/todo/5007001
+++ b/parts/todo/5007001
@@ -1,8 +1,5 @@
 5.007001
-ASCII_TO_NEED                  # U
-NATIVE_TO_NEED                 # U
 POPpbytex                      # E
-bytes_from_utf8                # U
 despatch_signals               # U
 do_openn                       # U
 gv_handler                     # U
@@ -15,8 +12,6 @@ sv_setref_uv                   # U
 sv_unref_flags                 # U
 sv_utf8_upgrade                # E (Perl_sv_utf8_upgrade)
 utf8_length                    # U
-utf8_to_uvchr                  # U
-utf8_to_uvuni                  # U
 utf8n_to_uvchr                 # U
 utf8n_to_uvuni                 # U
 uvchr_to_utf8                  # U

--- a/parts/todo/5007002
+++ b/parts/todo/5007002
@@ -14,4 +14,3 @@ sv_catsv_flags                 # U
 sv_setsv_flags                 # U
 sv_utf8_upgrade_flags          # U
 sv_utf8_upgrade_nomg           # U
-swash_fetch                    # E (Perl_swash_fetch)

--- a/parts/todo/5007003
+++ b/parts/todo/5007003
@@ -49,11 +49,6 @@ sv_nolocking                   # U
 sv_nosharing                   # U
 sv_recode_to_utf8              # U
 sv_uni_display                 # U
-to_uni_fold                    # U
-to_uni_lower                   # E (Perl_to_uni_lower)
-to_uni_title                   # E (Perl_to_uni_title)
-to_uni_upper                   # E (Perl_to_uni_upper)
-to_utf8_case                   # U
 unpack_str                     # U
 uvchr_to_utf8_flags            # U
 uvuni_to_utf8_flags            # U

--- a/parts/todo/5008000
+++ b/parts/todo/5008000
@@ -1,6 +1,3 @@
 5.008000
 HeUTF8                         # U
-hv_iternext_flags              # U
-hv_store_flags                 # U
-is_utf8_idcont                 # U
 nothreadhook                   # U

--- a/parts/todo/5008001
+++ b/parts/todo/5008001
@@ -8,7 +8,6 @@ is_utf8_string_loc             # U
 packlist                       # U
 pad_add_anon                   # U
 pad_new                        # E
-pad_tidy                       # E
 save_bool                      # U
 savestack_grow_cnt             # U
 seed                           # U

--- a/parts/todo/5009002
+++ b/parts/todo/5009002
@@ -1,6 +1,5 @@
 5.009002
 SvPVbyte_force                 # U
-find_rundefsvoffset            # U
 op_refcnt_lock                 # U
 op_refcnt_unlock               # U
 savesvpv                       # U

--- a/parts/todo/5009004
+++ b/parts/todo/5009004
@@ -3,7 +3,5 @@ PerlIO_context_layers          # U
 gv_name_set                    # U
 hv_copy_hints_hv               # U
 my_vsnprintf                   # U
-newXS_flags                    # U
-regclass_swash                 # E (Perl_regclass_swash)
 sv_does                        # U
 sv_usepvn_flags                # U

--- a/parts/todo/5009005
+++ b/parts/todo/5009005
@@ -1,14 +1,9 @@
 5.009005
-Perl_signbit                   # U
-av_create_and_push             # U
-av_create_and_unshift_one      # U
 gv_fetchfile_flags             # U
-lex_start                      # E (Perl_lex_start)
 mro_get_linear_isa             # U
 mro_method_changed_in          # U
 my_dirfd                       # U
 pregcomp                       # E (Perl_pregcomp)
-ptr_table_clear                # U
 ptr_table_fetch                # U
 ptr_table_free                 # U
 ptr_table_new                  # U

--- a/parts/todo/5011001
+++ b/parts/todo/5011001
@@ -1,6 +1,3 @@
 5.011001
 ck_warner                      # U
 ck_warner_d                    # U
-is_utf8_perl_space             # U
-is_utf8_perl_word              # U
-is_utf8_posix_digit            # U

--- a/parts/todo/5011002
+++ b/parts/todo/5011002
@@ -1,13 +1,2 @@
 5.011002
 PL_keyword_plugin              # E
-lex_bufutf8                    # U
-lex_discard_to                 # U
-lex_grow_linestr               # U
-lex_next_chunk                 # U
-lex_peek_unichar               # U
-lex_read_space                 # U
-lex_read_to                    # U
-lex_read_unichar               # U
-lex_stuff_pvn                  # U
-lex_stuff_sv                   # U
-lex_unstuff                    # U

--- a/parts/todo/5013005
+++ b/parts/todo/5013005
@@ -2,4 +2,3 @@
 PL_rpeepp                      # E
 isOCTAL                        # U
 lex_stuff_pvs                  # U
-parse_fullstmt                 # U

--- a/parts/todo/5013006
+++ b/parts/todo/5013006
@@ -7,7 +7,6 @@ ck_entersub_args_proto_or_list # U
 cv_get_call_checker            # E
 cv_set_call_checker            # E
 isWORDCHAR                     # U
-lex_stuff_pv                   # U
 mg_free_type                   # U
 newSVpv_share                  # U
 op_append_elem                 # U
@@ -15,7 +14,6 @@ op_append_list                 # U
 op_contextualize               # U
 op_linklist                    # U
 op_prepend_elem                # U
-parse_stmtseq                  # U
 rv2cv_op_cv                    # U
 savesharedpvs                  # U
 savesharedsvpv                 # U

--- a/parts/todo/5013007
+++ b/parts/todo/5013007
@@ -28,8 +28,3 @@ custom_op_register             # E
 custom_op_xop                  # E
 newFOROP                       # A
 newWHILEOP                     # A
-op_lvalue                      # U
-op_scope                       # U
-parse_barestmt                 # U
-parse_block                    # U
-parse_label                    # U

--- a/parts/todo/5013008
+++ b/parts/todo/5013008
@@ -1,6 +1,2 @@
 5.013008
 foldEQ_latin1                  # U
-parse_arithexpr                # U
-parse_fullexpr                 # U
-parse_listexpr                 # U
-parse_termexpr                 # U

--- a/parts/todo/5013010
+++ b/parts/todo/5013010
@@ -1,4 +1,1 @@
 5.013010
-foldEQ_utf8_flags              # U
-is_utf8_xidcont                # U
-is_utf8_xidfirst               # U

--- a/parts/todo/5014000
+++ b/parts/todo/5014000
@@ -1,2 +1,1 @@
 5.014000
-_to_uni_fold_flags             # U

--- a/parts/todo/5015001
+++ b/parts/todo/5015001
@@ -1,6 +1,4 @@
 5.015001
-cop_fetch_label                # U
-cop_store_label                # U
 pad_add_name_pv                # U
 pad_add_name_pvn               # U
 pad_add_name_pvs               # U

--- a/parts/todo/5015004
+++ b/parts/todo/5015004
@@ -12,9 +12,6 @@ gv_fetchmeth_pvn               # U
 gv_fetchmeth_pvn_autoload      # U
 gv_fetchmeth_sv                # U
 gv_fetchmeth_sv_autoload       # U
-gv_fetchmethod_pv_flags        # U
-gv_fetchmethod_pvn_flags       # U
-gv_fetchmethod_sv_flags        # U
 gv_init_pv                     # U
 gv_init_sv                     # U
 newGVgen_flags                 # U

--- a/parts/todo/5015009
+++ b/parts/todo/5015009
@@ -1,5 +1,2 @@
 5.015009
 utf8_to_uvchr_buf              # U
-utf8_to_uvuni_buf              # U
-valid_utf8_to_uvchr            # U
-valid_utf8_to_uvuni            # U

--- a/parts/todo/5017002
+++ b/parts/todo/5017002
@@ -1,7 +1,4 @@
 5.017002
-is_uni_blank                   # U
-is_uni_blank_lc                # U
-is_utf8_blank                  # U
 sv_copypv_flags                # U
 sv_copypv_nomg                 # U
 sv_vcatpvfn_flags              # U

--- a/parts/todo/5017007
+++ b/parts/todo/5017007
@@ -1,7 +1,2 @@
 5.017007
 SvREFCNT_dec_NN                # U
-_is_uni_perl_idstart           # U
-_is_utf8_perl_idstart          # U
-is_uni_alnumc                  # U
-is_uni_alnumc_lc               # U
-is_utf8_alnumc                 # U

--- a/parts/todo/5017008
+++ b/parts/todo/5017008
@@ -1,8 +1,3 @@
 5.017008
-_is_uni_FOO                    # U
-_is_uni_perl_idcont            # U
-_is_utf8_FOO                   # U
-_is_utf8_mark                  # U
-_is_utf8_perl_idcont           # U
 isALPHANUMERIC                 # U
 isIDCONT                       # U

--- a/parts/todo/5019004
+++ b/parts/todo/5019004
@@ -1,4 +1,3 @@
 5.019004
-append_utf8_from_native_byte   # U
 is_safe_syscall                # U
 uvoffuni_to_utf8_flags         # U

--- a/parts/todo/5019009
+++ b/parts/todo/5019009
@@ -1,5 +1,1 @@
 5.019009
-_to_utf8_fold_flags            # A
-_to_utf8_lower_flags           # A
-_to_utf8_title_flags           # A
-_to_utf8_upper_flags           # A

--- a/parts/todo/5021001
+++ b/parts/todo/5021001
@@ -1,12 +1,3 @@
 5.021001
-_is_in_locale_category         # U
-_is_utf8_char_slow             # U
-_is_utf8_idcont                # U
-_is_utf8_idstart               # U
-_is_utf8_xidcont               # U
-_is_utf8_xidstart              # U
-isALNUM_lazy                   # U
-isIDFIRST_lazy                 # U
 isUTF8_CHAR                    # U
 markstack_grow                 # E (Perl_markstack_grow)
-my_strerror                    # U

--- a/parts/todo/5021007
+++ b/parts/todo/5021007
@@ -1,9 +1,4 @@
 5.021007
 PadnameUTF8                    # E
 is_invariant_string            # U
-newPADNAMELIST                 # U
-newPADNAMEouter                # U
-newPADNAMEpvn                  # U
 newUNOP_AUX                    # E
-padnamelist_fetch              # U
-padnamelist_store              # U

--- a/parts/todo/5021008
+++ b/parts/todo/5021008
@@ -1,2 +1,1 @@
 5.021008
-sv_get_backrefs                # U

--- a/parts/todo/5023008
+++ b/parts/todo/5023008
@@ -1,22 +1,2 @@
 5.023008
 clear_defarray                 # U
-cx_popblock                    # U
-cx_popeval                     # U
-cx_popformat                   # U
-cx_popgiven                    # U
-cx_poploop                     # U
-cx_popsub                      # U
-cx_popsub_args                 # U
-cx_popsub_common               # U
-cx_popwhen                     # U
-cx_pushblock                   # U
-cx_pusheval                    # U
-cx_pushformat                  # U
-cx_pushgiven                   # U
-cx_pushloop_for                # U
-cx_pushloop_plain              # U
-cx_pushsub                     # U
-cx_pushwhen                    # U
-cx_topblock                    # U
-leave_adjust_stacks            # U
-savetmps                       # U


### PR DESCRIPTION
As fully described in the Changes file, this fixes the character
classification macros in all releases to match the same things they do
in modern perls.  EBCDIC is now supported.

isFOO_A synonyms are added for all isFOO classification macros.  In
modern perls, there are other macros that extend things beyond ASCII,
and the "_A" suffix makes it clear that just ASCII is needed.  Programs
should be able to use these and be understood on earlier perls.  The
macros that deal with beyond ASCII are not ported; generally perls
earlier than when the macros were defined are buggy in this range
anyway.

It would be possible to unify all but one macro between EBCDIC and
ASCII, but the result would be overly complicated for ASCII, and I chose
to keep those separate, but I did unify the ones where the new one is
clearer than the old, like isPUNCT using the literal punctuation
characters instead of ranges of ordinals whose meaning is not obvious.
