### PR TITLE
Don't redefine WIDEST_UTYPE

### DIFF
--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -322,6 +322,7 @@ __UNDEFINED__ isXDIGIT(c)       isxdigit(c)
 #  undef isPRINT
 # endif
 
+#ifndef WIDEST_UTYPE
 #ifdef HAS_QUAD
 # ifdef U64TYPE
 #  define WIDEST_UTYPE U64TYPE
@@ -330,6 +331,7 @@ __UNDEFINED__ isXDIGIT(c)       isxdigit(c)
 # endif
 #else
 # define WIDEST_UTYPE U32
+#endif
 #endif
 
 __UNDEFINED__ isALNUMC(c)       (isALPHA(c) || isDIGIT(c))


### PR DESCRIPTION
This was happening when compiling DBD::mysqlx 0.003 with DBI 1.642

Note that dbipport.h is a ppport.h

	In file included from /usr/lib64/perl5/vendor_perl/auto/DBI/DBIXS.h:38,
			 from dbdimp.h:11,
			 from mysqlx.h:7,
			 from mysqlx.xs:10:
	/usr/lib64/perl5/vendor_perl/auto/DBI/dbipport.h:4471: warning: "WIDEST_UTYPE" redefined
	 #  define WIDEST_UTYPE U64TYPE

	In file included from /usr/lib64/perl5/CORE/perl.h:2465,
			 from /usr/lib64/perl5/vendor_perl/auto/DBI/DBIXS.h:23,
			 from dbdimp.h:11,
			 from mysqlx.h:7,
			 from mysqlx.xs:10:
	/usr/lib64/perl5/CORE/handy.h:1064: note: this is the location of the previous definition
	 #   define WIDEST_UTYPE U64