### PR TITLE
fix leak in Devel-PPPort

### DIFF
--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -578,6 +578,7 @@ OpSIBLING_tests()
 	PREINIT:
 		OP *x;
 		OP *kid;
+		OP *middlekid;
 		OP *lastkid;
 		int count = 0;
 		int failures = 0;
@@ -601,6 +602,7 @@ OpSIBLING_tests()
 			kid = OpSIBLING(kid);
 			lastkid = kid;
 		}
+                middlekid = OpSIBLING(x);
 
 		/* Should now have a sibling */
 		if (! OpHAS_SIBLING(x) || ! OpSIBLING(x) ) {
@@ -644,6 +646,9 @@ OpSIBLING_tests()
 			failures++; warn("Op should have had a sib after maybesibset");
 		}
 
+                op_free(lastkid);
+                op_free(middlekid);
+                op_free(x);
 		RETVAL = failures;
 	OUTPUT:
 		RETVAL


### PR DESCRIPTION
The leaky code is only used during test. It creates 3 ops, does various
operations related to linking OpSIBLINGs, then fails to free them.