### PR TITLE
Fix tests for 64bit int, 32bit ptr platforms

### DIFF
--- a/parts/inc/uv
+++ b/parts/inc/uv
@@ -383,7 +383,12 @@ utf8_to_uvchr_buf(s, adjustment)
             av_push(av, newSVuv(utf8_to_uvchr_buf(s,
                                                   s + UTF8SKIP(s) + adjustment,
                                                   &len)));
-            av_push(av, newSViv((IV) len));
+            if (len == (STRLEN) -1) {
+                av_push(av, newSViv(-1));
+            }
+            else {
+                av_push(av, newSVuv(len));
+            }
             RETVAL = av;
         OUTPUT:
                 RETVAL
@@ -397,7 +402,12 @@ utf8_to_uvchr(s)
         CODE:
             av = newAV();
             av_push(av, newSVuv(utf8_to_uvchr(s, &len)));
-            av_push(av, newSViv((IV) len));
+            if (len == (STRLEN) -1) {
+                av_push(av, newSViv(-1));
+            }
+            else {
+                av_push(av, newSVuv(len));
+            }
             RETVAL = av;
         OUTPUT:
                 RETVAL


### PR DESCRIPTION
The xs code that interfaces between the .t and the C code was not
properly dealing with the size differences.  I copied the similar code
from perl core XS-APItest, and that works