### PR TITLE
5.30 utf8_to_uvchr_buf still has wrong retval

### DIFF
--- a/parts/inc/uv
+++ b/parts/inc/uv
@@ -85,7 +85,7 @@ my_strnlen(const char *str, Size_t maxlen)
 #endif
 #endif
 
-#if { VERSION < 5.30.0 }
+#if { VERSION < 5.31.2 }
         /* Versions prior to this accepted things that are now considered
          * malformations, and didn't return -1 on error with warnings enabled
          * */


### PR DESCRIPTION
Wrong for some failure conditions, anyway.  It should get fixed early in
5.31, make the cutoff here 5.31.2 to give us some leeway, so don't have
to change Devel::PPPort again.