### PR TITLE
Attempt to solve compilation issues on older Perl version

### DIFF
--- a/PPPort_pm.PL
+++ b/PPPort_pm.PL
@@ -628,6 +628,8 @@ __DATA__
 
 %include limits
 
+%include magic_defs
+
 %include misc
 
 %include warn
@@ -635,8 +637,6 @@ __DATA__
 %include uv
 
 %include memory
-
-%include magic_defs
 
 %include mess
 

--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -33,6 +33,14 @@ STMT_END
 STMT_START
 SvRX
 UTF8_MAXBYTES
+UTF8_ALLOW_ANYUV
+UTF8_ALLOW_EMPTY
+UTF8_ALLOW_CONTINUATION
+UTF8_ALLOW_NON_CONTINUATION
+UTF8_ALLOW_SHORT
+UTF8_ALLOW_LONG
+UTF8_ALLOW_OVERFLOW
+UTF8_ALLOW_ANY
 WIDEST_UTYPE
 XSRETURN
 
@@ -259,6 +267,19 @@ __UNDEFINED__  dVAR            dNOOP
 __UNDEFINED__  SVf             "_"
 
 __UNDEFINED__  UTF8_MAXBYTES   UTF8_MAXLEN
+
+__UNDEFINED__  UTF8_ALLOW_ANYUV                 0
+__UNDEFINED__  UTF8_ALLOW_EMPTY            0x0001
+__UNDEFINED__  UTF8_ALLOW_CONTINUATION     0x0002
+__UNDEFINED__  UTF8_ALLOW_NON_CONTINUATION 0x0004
+__UNDEFINED__  UTF8_ALLOW_SHORT            0x0008
+__UNDEFINED__  UTF8_ALLOW_LONG             0x0010
+__UNDEFINED__  UTF8_ALLOW_OVERFLOW         0x0080
+__UNDEFINED__  UTF8_ALLOW_ANY            ( UTF8_ALLOW_CONTINUATION      \
+                                          |UTF8_ALLOW_NON_CONTINUATION  \
+                                          |UTF8_ALLOW_SHORT             \
+                                          |UTF8_ALLOW_LONG              \
+                                          |UTF8_ALLOW_OVERFLOW)
 
 __UNDEFINED__  CPERLscope(x)   x
 
@@ -1122,17 +1143,17 @@ test_isPSXSPC_A(UV ord)
 
 STRLEN
 av_tindex(av)
-        AV *av
+        SV *av
         CODE:
-                RETVAL = av_tindex(av);
+                RETVAL = av_tindex((AV*)SvRV(av));
         OUTPUT:
                 RETVAL
 
 STRLEN
 av_top_index(av)
-        AV *av
+        SV *av
         CODE:
-                RETVAL = av_top_index(av);
+                RETVAL = av_top_index((AV*)SvRV(av));
         OUTPUT:
                 RETVAL
 

--- a/parts/inc/uv
+++ b/parts/inc/uv
@@ -109,8 +109,10 @@ my_strnlen(const char *str, Size_t maxlen)
 #  if defined(utf8n_to_uvchr) || defined(utf8_to_uv)
 #    if defined(utf8n_to_uvchr)   /* This is the preferred implementation */
 #      define _ppport_utf8_to_uvchr_buf_callee utf8n_to_uvchr
-#    else
+#    elif { VERSION >= 5.6.1 }
 #      define _ppport_utf8_to_uvchr_buf_callee utf8_to_uv
+#    else
+#      define _ppport_utf8_to_uvchr_buf_callee(s, curlen, retlen, flags) utf8_to_uv(s, retlen)
 #    endif
 
 #  endif


### PR DESCRIPTION
from @pali 

> you have wrong order of includes in PPPort_pm.PL
misc uses defines from magic_defs
but magic_defs is after misc
so it cause compile error on older perl versions

