### PR TITLE
Devel::PPPort: Run make regen after regenerating Makefile

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ require 5.003;
 
 use strict;
 use ExtUtils::MakeMaker;
+use Config;
 
 use vars '%opt';  # needs to be global, and we can't use 'our'
 
@@ -37,6 +38,7 @@ my %mf = (
 );
 delete $mf{META_MERGE} unless eval { ExtUtils::MakeMaker->VERSION (6.46) };
 WriteMakefile(%mf);
+system({$Config{make}} $Config{make}, 'regen');
 
 sub configure
 {


### PR DESCRIPTION
Resolves GH #76, RT 134114

This would ensure that all auto-generated files are up-to-date after running configure phase.

(cherry picked from commit 14d33d137d5c30a8a755a201fa4c8c5c4a7ae74d)
Signed-off-by: Nicolas R <atoomic@cpan.org>