### PR TITLE
dist target now depends on manifest

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -150,6 +150,7 @@ sub MY::dist_core
   my @rules = split( m{^\s*$}m, $dist );
   foreach my $rule ( @rules ) {
     if ( $rule =~ m{^\s*^dist\s+:}m ) {
+        $rule =~ s{:}{: manifest}; # make sure we regenerate the manifest
         $rule .= qq[\t].q[$(NOECHO) $(ECHO) "Warning: Please check '__MAX_PERL__' value in PPPort_pm.PL"].qq[\n];
     }
     $updated .= $rule;


### PR DESCRIPTION
Fixes GH #68

make sure we regenerate the manifest
when building a dist.

We recently removed on purpose the
MANIFEST file from the git repo to
make sure we always generate a fresh
version on dist...