### PR TITLE
Define more API functions as macros

### DIFF
--- a/parts/apicheck.pl
+++ b/parts/apicheck.pl
@@ -152,24 +152,16 @@ print OUT <<HEAD;
 #define NEED_my_strlcat
 #define NEED_my_strlcpy
 #define NEED_newCONSTSUB
-#define NEED_newRV_noinc
-#define NEED_newSV_type
-#define NEED_newSVpvn_flags
 #define NEED_newSVpvn_share
 #define NEED_pv_display
 #define NEED_pv_escape
 #define NEED_pv_pretty
-#define NEED_sv_2pv_flags
-#define NEED_sv_2pvbyte
 #define NEED_sv_catpvf_mg
 #define NEED_sv_catpvf_mg_nocontext
-#define NEED_sv_pvn_force_flags
 #define NEED_sv_setpvf_mg
 #define NEED_sv_setpvf_mg_nocontext
 #define NEED_sv_unmagicext
-#define NEED_SvRX
 #define NEED_vload_module
-#define NEED_vnewSVpvf
 #define NEED_warner
 
 #include "ppport.h"

--- a/parts/inc/SvPV
+++ b/parts/inc/SvPV
@@ -17,20 +17,7 @@ sv_2pvbyte
 sv_2pv_flags
 sv_pvn_force_flags
 
-=dontwarn
-
-NEED_sv_2pv_flags
-NEED_sv_2pv_flags_GLOBAL
-
 =implementation
-
-/* Backwards compatibility stuff... :-( */
-#if !defined(NEED_sv_2pv_flags) && defined(NEED_sv_2pv_nolen)
-#  define NEED_sv_2pv_flags
-#endif
-#if !defined(NEED_sv_2pv_flags_GLOBAL) && defined(NEED_sv_2pv_nolen_GLOBAL)
-#  define NEED_sv_2pv_flags_GLOBAL
-#endif
 
 /* Hint: sv_2pv_nolen
  * Use the SvPV_nolen() or SvPV_nolen_const() macros instead of sv_2pv_nolen().
@@ -47,16 +34,7 @@ __UNDEFINED__  sv_2pv_nolen(sv)   SvPV_nolen(sv)
 
 #if { VERSION < 5.7.0 }
 
-#if { NEED sv_2pvbyte }
-
-char *
-sv_2pvbyte(pTHX_ SV *sv, STRLEN *lp)
-{
-  sv_utf8_downgrade(sv,0);
-  return SvPV(sv,*lp);
-}
-
-#endif
+__UNDEFINED__ sv_2pvbyte(sv, lp) (sv_utf8_downgrade((sv), 0), SvPV((sv), *(lp)))
 
 /* Hint: sv_2pvbyte
  * Use the SvPVbyte() macro instead of sv_2pvbyte().
@@ -101,27 +79,8 @@ __UNDEFINED__  SV_COW_SHARED_HASH_KEYS  0
 
 #if { VERSION < 5.7.2 }
 
-#if { NEED sv_2pv_flags }
-
-char *
-sv_2pv_flags(pTHX_ SV *sv, STRLEN *lp, I32 flags)
-{
-  STRLEN n_a = (STRLEN) flags;
-  return sv_2pv(sv, lp ? lp : &n_a);
-}
-
-#endif
-
-#if { NEED sv_pvn_force_flags }
-
-char *
-sv_pvn_force_flags(pTHX_ SV *sv, STRLEN *lp, I32 flags)
-{
-  STRLEN n_a = (STRLEN) flags;
-  return sv_pvn_force(sv, lp ? lp : &n_a);
-}
-
-#endif
+__UNDEFINED__ sv_2pv_flags(sv, lp, flags) sv_2pv((sv), (lp) ? (lp) : &PL_na)
+__UNDEFINED__ sv_pvn_force_flags(sv, lp, flags) sv_pvn_force((sv), (lp) ? (lp) : &PL_na)
 
 #endif
 
@@ -190,12 +149,6 @@ __UNDEFINED__  SvPV_renew(sv,n) STMT_START { SvLEN_set(sv, n); \
                  SvPV_set((sv), (char *) saferealloc(          \
                        (Malloc_t)SvPVX(sv), (MEM_SIZE)((n)))); \
                } STMT_END
-
-=xsinit
-
-#define NEED_sv_2pv_flags
-#define NEED_sv_pvn_force_flags
-#define NEED_sv_2pvbyte
 
 =xsubs
 

--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -60,26 +60,7 @@ __UNDEFINED__ __ASSERT_(statement)  assert(statement),
 __UNDEFINED__ __ASSERT_(statement)
 #endif
 
-#ifndef SvRX
-#if { NEED SvRX }
-
-void *
-SvRX(pTHX_ SV *rv)
-{
-	if (SvROK(rv)) {
-		SV *sv = SvRV(rv);
-		if (SvMAGICAL(sv)) {
-			MAGIC *mg = mg_find(sv, PERL_MAGIC_qr);
-			if (mg && mg->mg_obj) {
-				return mg->mg_obj;
-			}
-		}
-	}
-	return 0;
-}
-#endif
-#endif
-
+__UNDEFINED__ SvRX(rv) (SvROK((rv)) ? (SvMAGICAL(SvRV((rv))) ? (mg_find(SvRV((rv)), PERL_MAGIC_qr) ? mg_find(SvRV((rv)), PERL_MAGIC_qr)->mg_obj : NULL) : NULL) : NULL)
 __UNDEFINED__ SvRXOK(sv) (!!SvRX(sv))
 
 #ifndef PERL_UNUSED_DECL
@@ -579,10 +560,6 @@ XS(XS_Devel__PPPort_dAXMARK)
   mPUSHi(iv);
   XSRETURN(1);
 }
-
-=xsinit
-
-#define NEED_SvRX
 
 =xsboot
 

--- a/parts/inc/newRV
+++ b/parts/inc/newRV
@@ -19,20 +19,12 @@ newRV_noinc
 __UNDEFINED__  newRV_inc(sv)  newRV(sv)   /* Replace */
 
 #ifndef newRV_noinc
-#if { NEED newRV_noinc }
-SV *
-newRV_noinc(SV *sv)
-{
-  SV *rv = (SV *)newRV(sv);
-  SvREFCNT_dec(sv);
-  return rv;
-}
+#if defined(__GNUC__) && !defined(PERL_GCC_BRACE_GROUPS_FORBIDDEN)
+#  define newRV_noinc(sv) ({ SV *_sv = (SV *)newRV((sv)); SvREFCNT_dec((sv)); _sv; })
+#else
+#  define newRV_noinc(sv) ((PL_Sv = (SV *)newRV((sv))), SvREFCNT_dec((sv)), PL_Sv)
 #endif
 #endif
-
-=xsinit
-
-#define NEED_newRV_noinc
 
 =xsubs
 

--- a/parts/inc/newSV_type
+++ b/parts/inc/newSV_type
@@ -16,24 +16,12 @@ newSV_type
 =implementation
 
 #ifndef newSV_type
-
-#if { NEED newSV_type }
-
-SV*
-newSV_type(pTHX_ svtype const t)
-{
-  SV* const sv = newSV(0);
-  sv_upgrade(sv, t);
-  return sv;
-}
-
+#if defined(__GNUC__) && !defined(PERL_GCC_BRACE_GROUPS_FORBIDDEN)
+#  define newSV_type(t) ({ SV *_sv = newSV(0); sv_upgrade(_sv, (t)); _sv; })
+#else
+#  define newSV_type(t) ((PL_Sv = newSV(0)), sv_upgrade(PL_Sv, (t)), PL_Sv)
 #endif
-
 #endif
-
-=xsinit
-
-#define NEED_newSV_type
 
 =xsubs
 

--- a/parts/inc/newSVpv
+++ b/parts/inc/newSVpv
@@ -31,24 +31,12 @@ __UNDEFINED__  newSVpvn_utf8(s, len, u)  newSVpvn_flags((s), (len), (u) ? SVf_UT
 __UNDEFINED__  SVf_UTF8  0
 
 #ifndef newSVpvn_flags
-
-#if { NEED newSVpvn_flags }
-
-SV *
-newSVpvn_flags(pTHX_ const char *s, STRLEN len, U32 flags)
-{
-  SV *sv = newSVpvn(D_PPP_CONSTPV_ARG(s), len);
-  SvFLAGS(sv) |= (flags & SVf_UTF8);
-  return (flags & SVs_TEMP) ? sv_2mortal(sv) : sv;
-}
-
+#if defined(__GNUC__) && !defined(PERL_GCC_BRACE_GROUPS_FORBIDDEN)
+# define newSVpvn_flags(s, len, flags) ({ SV *_sv = newSVpvn(D_PPP_CONSTPV_ARG((s)), (len)); SvFLAGS(_sv) |= ((flags) & SVf_UTF8); ((flags) & SVs_TEMP) ? sv_2mortal(_sv) : _sv; })
+#else
+# define newSVpvn_flags(s, len, flags) ((PL_Sv = newSVpvn(D_PPP_CONSTPV_ARG((s)), (len))), SvFLAGS(PL_Sv) |= ((flags) & SVf_UTF8), (((flags) & SVs_TEMP) ? sv_2mortal(PL_Sv) : PL_Sv))
 #endif
-
 #endif
-
-=xsinit
-
-#define NEED_newSVpvn_flags
 
 =xsubs
 

--- a/parts/inc/ppphtest
+++ b/parts/inc/ppphtest
@@ -350,7 +350,6 @@ ok($o =~ /^\s*$/);
 ---------------------------- file1.xs -----------------------------------------
 
 #define NEED_newCONSTSUB
-#define NEED_sv_2pv_flags
 #define NEED_PL_parser
 #include "ppport.h"
 
@@ -522,7 +521,6 @@ call_pv();
 #define NEED_eval_pv_GLOBAL
 #define NEED_grok_hex
 #define NEED_newCONSTSUB_GLOBAL
-#define NEED_sv_2pv_flags_GLOBAL
 #include "ppport.h"
 
 newCONSTSUB();
@@ -879,8 +877,6 @@ for (qw(file.xs)) {
 
 ---------------------------- file.xs -----------------------------------------
 
-#define NEED_sv_2pv_flags
-#define NEED_vnewSVpvf
 #define NEED_warner
 #include "ppport.h"
 Perl_croak_nocontext("foo");
@@ -894,8 +890,6 @@ warner("foo");
 
 ---------------------------- file.xsr -----------------------------------------
 
-#define NEED_sv_2pv_flags
-#define NEED_vnewSVpvf
 #define NEED_warner
 #include "ppport.h"
 Perl_croak_nocontext("foo");

--- a/parts/inc/sv_xpvf
+++ b/parts/inc/sv_xpvf
@@ -26,16 +26,10 @@ sv_vsetpvf_mg
 =implementation
 
 #if { VERSION >= 5.004 } && !defined(vnewSVpvf)
-#if { NEED vnewSVpvf }
-
-SV *
-vnewSVpvf(pTHX_ const char *pat, va_list *args)
-{
-  register SV *sv = newSV(0);
-  sv_vsetpvfn(sv, pat, strlen(pat), args, Null(SV**), 0, Null(bool*));
-  return sv;
-}
-
+#if defined(__GNUC__) && !defined(PERL_GCC_BRACE_GROUPS_FORBIDDEN)
+#  define vnewSVpvf(pat, args) ({ SV *_sv = newSV(0); sv_vsetpvfn(_sv, (pat), strlen((pat)), (args), Null(SV**), 0, Null(bool*)); _sv; })
+#else
+#  define vnewSVpvf(pat, args) ((PL_Sv = newSV(0)), sv_vsetpvfn(PL_Sv, (pat), strlen((pat)), (args), Null(SV**), 0, Null(bool*)), PL_Sv)
 #endif
 #endif
 
@@ -153,7 +147,6 @@ sv_setpvf_mg_nocontext(SV *sv, const char *pat, ...)
 
 =xsinit
 
-#define NEED_vnewSVpvf
 #define NEED_sv_catpvf_mg
 #define NEED_sv_catpvf_mg_nocontext
 #define NEED_sv_setpvf_mg

--- a/t/ppphtest.t
+++ b/t/ppphtest.t
@@ -387,7 +387,6 @@ ok($o =~ /^\s*$/);
 ---------------------------- file1.xs -----------------------------------------
 
 #define NEED_newCONSTSUB
-#define NEED_sv_2pv_flags
 #define NEED_PL_parser
 #include "ppport.h"
 
@@ -559,7 +558,6 @@ call_pv();
 #define NEED_eval_pv_GLOBAL
 #define NEED_grok_hex
 #define NEED_newCONSTSUB_GLOBAL
-#define NEED_sv_2pv_flags_GLOBAL
 #include "ppport.h"
 
 newCONSTSUB();
@@ -916,8 +914,6 @@ for (qw(file.xs)) {
 
 ---------------------------- file.xs -----------------------------------------
 
-#define NEED_sv_2pv_flags
-#define NEED_vnewSVpvf
 #define NEED_warner
 #include "ppport.h"
 Perl_croak_nocontext("foo");
@@ -931,8 +927,6 @@ warner("foo");
 
 ---------------------------- file.xsr -----------------------------------------
 
-#define NEED_sv_2pv_flags
-#define NEED_vnewSVpvf
 #define NEED_warner
 #include "ppport.h"
 Perl_croak_nocontext("foo");


### PR DESCRIPTION
So their usage via ppport.h can be done via specifying corresponding NEED_.