### PR TITLE
parts/inc/uv: A char* should be a U8*

### DIFF
--- a/devel/mkapidoc.sh
+++ b/devel/mkapidoc.sh
@@ -74,8 +74,8 @@ if isperlroot $PERLROOT; then
 
 EOF
   grep -hr '^=for apidoc' $PERLROOT | sed -e 's/=for apidoc //' | grep '|' | sort | uniq \
-     | perl -e'$f=pop;open(F,$f)||die"$f:$!";while(<F>){(split/\|/)[2]=~/(\w+)/;$h{$1}++}
-               while(<>){s/[ \t]+$//;(split/\|/)[2]=~/(\w+)/;$h{$1}||print}' $EMBED >>$OUTPUT
+     | perl -e'$f=pop;open(F,$f)||die"$f:$!";while(<F>){(split/\s*\|\s*/)[2]=~/(\w+)/;$h{$1}++}
+               while(<>){s/[ \t]+$//;(split/\s*\|\s*/)[2]=~/(\w+)/;$h{$1}||print}' $EMBED >>$OUTPUT
 else
   usage
 fi

--- a/parts/inc/uv
+++ b/parts/inc/uv
@@ -411,7 +411,7 @@ utf8_to_uvchr_buf(s, adjustment)
         PREINIT:
             AV *av;
             STRLEN len;
-            const char *const_s;
+            const unsigned char *const_s;
         CODE:
             av = newAV();
             const_s = s;
@@ -438,7 +438,7 @@ utf8_to_uvchr(s)
         PREINIT:
             AV *av;
             STRLEN len;
-            const char *const_s;
+            const unsigned char *const_s;
         CODE:
             av = newAV();
             const_s = s;


### PR DESCRIPTION
Without this, it doesn't compile for me, but I don't know why it seems to in other environments