### PR TITLE
mkapidoc.sh: Add required line to generated apidoc.fnc

### DIFF
--- a/devel/mkapidoc.sh
+++ b/devel/mkapidoc.sh
@@ -72,6 +72,10 @@ if isperlroot $PERLROOT; then
 : source code, but are not contained in F<embed.fnc>.
 :
 
+: This line needs to be in this file for things to work, even though it's been
+: removed from later embed.fnc versions
+Apnod   |int    |my_sprintf     |NN char *buffer|NN const char *pat|...
+
 EOF
   grep -hr '^=for apidoc' $PERLROOT | sed -e 's/=for apidoc //' | grep '|' | sort | uniq \
      | perl -e'$f=pop;open(F,$f)||die"$f:$!";while(<F>){(split/\s*\|\s*/)[2]=~/(\w+)/;$h{$1}++}

--- a/parts/apidoc.fnc
+++ b/parts/apidoc.fnc
@@ -13,6 +13,10 @@
 : source code, but are not contained in F<embed.fnc>.
 :
 
+: This line needs to be in this file for things to work, even though it's been
+: removed from later embed.fnc versions
+Apnod   |int    |my_sprintf     |NN char *buffer|NN const char *pat|...
+
 Ama|char*|savepvs|"literal string" s
 Ama|char*|savesharedpvs|"literal string" s
 Ama|SV*|newSVpvs_flags|"literal string" s|U32 flags

--- a/parts/ppptools.pl
+++ b/parts/ppptools.pl
@@ -306,6 +306,7 @@ sub parse_embed
         my @e = split /\s*\|\s*/, $line;
         if( @e >= 3 ) {
           my($flags, $ret, $name, @args) = @e;
+          next unless $flags =~ /A/; # Skip non-public entries
           next if $flags =~ /[DM]/; # Skip entries marked as deprecated or unstable
           if ($name =~ /^[^\W\d]\w*$/) {
             for (@args) {


### PR DESCRIPTION
Instead of expecting whoever is updating the embed.fnc to remember that
this extra line is required, do it while parsing it.  This means that
the embed.fnc can just be copied from the latest blead.