### PR TITLE
Test Strawberry Perl on Travis Windows Build Environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,8 +172,74 @@ matrix:
     - perl: system_xenial
       dist: xenial
 
+    - perl: "5.26.0.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86 TRAVIS_PERL_VERSION="5.26.0.1"
+    - perl: "5.26.0.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86_64 TRAVIS_PERL_VERSION="5.26.0.1"
+    - perl: "5.26.1.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86 TRAVIS_PERL_VERSION="5.26.1.1"
+    - perl: "5.26.1.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86_64 TRAVIS_PERL_VERSION="5.26.1.1"
+    - perl: "5.26.2.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86 TRAVIS_PERL_VERSION="5.26.2.1"
+    - perl: "5.26.2.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86_64 TRAVIS_PERL_VERSION="5.26.2.1"
+    - perl: "5.26.3.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86 TRAVIS_PERL_VERSION="5.26.3.1"
+    - perl: "5.26.3.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86_64 TRAVIS_PERL_VERSION="5.26.3.1"
+    - perl: "5.28.0.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86 TRAVIS_PERL_VERSION="5.28.0.1"
+    - perl: "5.28.0.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86_64 TRAVIS_PERL_VERSION="5.28.0.1"
+    - perl: "5.28.1.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86 TRAVIS_PERL_VERSION="5.28.1.1"
+    - perl: "5.28.1.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86_64 TRAVIS_PERL_VERSION="5.28.1.1"
+    - perl: "5.28.2.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86 TRAVIS_PERL_VERSION="5.28.2.1"
+    - perl: "5.28.2.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86_64 TRAVIS_PERL_VERSION="5.28.2.1"
+    - perl: "5.30.0.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86 TRAVIS_PERL_VERSION="5.30.0.1"
+    - perl: "5.30.0.1"
+      os: windows
+      language: shell
+      env: PLATFORM=x86_64 TRAVIS_PERL_VERSION="5.30.0.1"
+
 before_install:
-  - if ! [[ $TRAVIS_PERL_VERSION =~ ^system ]] && [ -z "$PERLBREW_PERL" ]; then eval $(curl https://travis-perl.github.io/init) --perl; fi
+  - if ! [[ $TRAVIS_PERL_VERSION =~ ^system ]] && [ -z "$PERLBREW_PERL" ] && [ "$TRAVIS_OS_NAME" != "windows" ]; then eval $(curl https://travis-perl.github.io/init) --perl; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then cinst StrawberryPerl $([ "$PLATFORM" = "x86" ] && echo --forcex86) --version "$TRAVIS_PERL_VERSION"; export PATH="/c/Strawberry/perl/site/bin:/c/Strawberry/perl/bin:/c/Strawberry/c/bin:$PATH"; perl -MConfig -e 'print "#!/bin/sh\n$Config{make} \"\$@\"\n"' > /c/Strawberry/perl/site/bin/make; chmod +x /c/Strawberry/perl/site/bin/make; fi
 
 install:
   - perl Makefile.PL

--- a/.travis.yml
+++ b/.travis.yml
@@ -245,7 +245,7 @@ install:
   - perl Makefile.PL
   - make regen
 # ensure allfiles are git up-to-date [fail if make regen alters some files]
-  - git diff --quiet
+  - [ "$TRAVIS_OS_NAME" != "windows" ] && git diff --quiet
 
 script:
   - perl Makefile.PL


### PR DESCRIPTION
Unfortunately, dmake-based Strawberry Perl (prior 5.26) does not work.