### PR TITLE
Fix mktests.PL to produce same output on Linux and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -245,7 +245,7 @@ install:
   - perl Makefile.PL
   - make regen
 # ensure allfiles are git up-to-date [fail if make regen alters some files]
-  - test "$TRAVIS_OS_NAME" = "windows" || git diff --quiet
+  - git diff --quiet
 
 script:
   - perl Makefile.PL

--- a/mktests.PL
+++ b/mktests.PL
@@ -41,7 +41,9 @@ sub generate_tests
       print "generating $testfile\n";
 
       my $tmpl = $template;
-      $tmpl =~ s/__SOURCE__/$file/mg;
+      my $canonfile = $file;
+      $canonfile =~ tr!\\!/!; # MSWin32 use backslashes
+      $tmpl =~ s/__SOURCE__/$canonfile/mg;
       $tmpl =~ s/__PLAN__/$spec->{OPTIONS}{tests}{plan}/mg;
       $tmpl =~ s/^__TESTS__$/$spec->{tests}/mg;
 


### PR DESCRIPTION
MSWin32 use backslashes, so change them to slashes.

Fixes #106