### PR TITLE
Use ppport's utf8_to_uvchr_buf through 5.31.3

### DIFF
--- a/parts/inc/uv
+++ b/parts/inc/uv
@@ -90,7 +90,7 @@ my_strnlen(const char *str, Size_t maxlen)
 #endif
 #endif
 
-#if { VERSION < 5.31.2 }
+#if { VERSION < 5.31.3 }
         /* Versions prior to this accepted things that are now considered
          * malformations, and didn't return -1 on error with warnings enabled
          * */


### PR DESCRIPTION
I failed to push the fix to blead in time for 5.31.2, so continue to use
the fixed version in ppport.  I will shortly fix blead.