### PR TITLE
Fixes for apicheck

### DIFF
--- a/devel/mktodo.pl
+++ b/devel/mktodo.pl
@@ -20,7 +20,18 @@ use Data::Dumper;
 use IO::File;
 use IO::Select;
 use Config;
-use Time::HiRes qw( gettimeofday tv_interval );
+
+BEGIN {
+  eval {
+    require Time::HiRes;
+    Time::HiRes->import('gettimeofday');
+    1;
+  } or do {
+    *gettimeofday = sub() {
+      return wantarray ? (time(), 0) : time();
+    };
+  }
+}
 
 require './devel/devtools.pl';
 

--- a/parts/ppptools.pl
+++ b/parts/ppptools.pl
@@ -231,6 +231,8 @@ sub trim_arg
 
   $in eq '...' and return ($in);
 
+  $in =~ s/"literal string"/const char */;
+
   local $_ = $in;
   my $id;
 


### PR DESCRIPTION
* Fix parsing "literal string" argument in fnc files
* Allow to run mktodo.pl under Perl versions prior to 5.8.0

CC @khwilliamson