### PR TITLE
Fix compilation with Visual C++

### DIFF
--- a/parts/inc/utf8
+++ b/parts/inc/utf8
@@ -86,8 +86,9 @@ __UNDEF_NOT_PROVIDED__ UTF8_ALLOW_ANY  ( UTF8_ALLOW_CONTINUATION      \
 
 #if defined UTF8SKIP
 
-/* Don't use official version because it uses MIN, which may not be available */
+/* Don't use official versions because they use MIN, which may not be available */
 #undef UTF8_SAFE_SKIP
+#undef UTF8_CHK_SKIP
 
 __UNDEFINED__  UTF8_SAFE_SKIP(s, e)  (                                          \
                                       ((((e) - (s)) <= 0)                       \


### PR DESCRIPTION
```
   Creating library blib\arch\auto\Devel\PPPort\PPPort.lib and object blib\arch\auto\Devel\PPPort\PPPort.exp
RealPPPort.obj : error LNK2001: unresolved external symbol MIN
blib\arch\auto\Devel\PPPort\PPPort.dll : fatal error LNK1120: 1 unresolved externals
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\bin\HostX64\x64\link.EXE"' : return code '0x460'
Stop.
```