### PR TITLE
fix mess.t failures when $0 contains backslashes

### DIFF
--- a/parts/inc/mess
+++ b/parts/inc/mess
@@ -332,8 +332,8 @@ ok $die, "\xE1\n";
 
 undef $die;
 ok !defined eval { Devel::PPPort::croak_sv(10) };
-ok $@ =~ /^10 at $0 line /;
-ok $die =~ /^10 at $0 line /;
+ok $@ =~ /^10 at \Q$0\E line /;
+ok $die =~ /^10 at \Q$0\E line /;
 
 undef $die;
 $@ = 'should not be visible (1)';
@@ -341,8 +341,8 @@ ok !defined eval {
     $@ = 'should not be visible (2)';
     Devel::PPPort::croak_sv('');
 };
-ok $@ =~ /^ at $0 line /;
-ok $die =~ /^ at $0 line /;
+ok $@ =~ /^ at \Q$0\E line /;
+ok $die =~ /^ at \Q$0\E line /;
 
 undef $die;
 $@ = 'should not be visible';
@@ -350,8 +350,8 @@ ok !defined eval {
     $@ = 'this must be visible';
     Devel::PPPort::croak_sv($@)
 };
-ok $@ =~ /^this must be visible at $0 line /;
-ok $die =~ /^this must be visible at $0 line /;
+ok $@ =~ /^this must be visible at \Q$0\E line /;
+ok $die =~ /^this must be visible at \Q$0\E line /;
 
 undef $die;
 $@ = 'should not be visible';
@@ -368,8 +368,8 @@ ok !defined eval {
     $@ = 'this must be visible';
     Devel::PPPort::croak_sv_errsv()
 };
-ok $@ =~ /^this must be visible at $0 line /;
-ok $die =~ /^this must be visible at $0 line /;
+ok $@ =~ /^this must be visible at \Q$0\E line /;
+ok $die =~ /^this must be visible at \Q$0\E line /;
 
 undef $die;
 $@ = 'should not be visible';
@@ -387,18 +387,18 @@ ok Devel::PPPort::get_counter(), 1;
 
 undef $die;
 ok !defined eval { Devel::PPPort::croak_sv('') };
-ok $@ =~ /^ at $0 line /;
-ok $die =~ /^ at $0 line /;
+ok $@ =~ /^ at \Q$0\E line /;
+ok $die =~ /^ at \Q$0\E line /;
 
 undef $die;
 ok !defined eval { Devel::PPPort::croak_sv("\xE1") };
-ok $@ =~ /^\xE1 at $0 line /;
-ok $die =~ /^\xE1 at $0 line /;
+ok $@ =~ /^\xE1 at \Q$0\E line /;
+ok $die =~ /^\xE1 at \Q$0\E line /;
 
 undef $die;
 ok !defined eval { Devel::PPPort::croak_sv("\xC3\xA1") };
-ok $@ =~ /^\xC3\xA1 at $0 line /;
-ok $die =~ /^\xC3\xA1 at $0 line /;
+ok $@ =~ /^\xC3\xA1 at \Q$0\E line /;
+ok $die =~ /^\xC3\xA1 at \Q$0\E line /;
 
 undef $warn;
 Devel::PPPort::warn_sv("\xE1\n");
@@ -406,34 +406,34 @@ ok $warn, "\xE1\n";
 
 undef $warn;
 Devel::PPPort::warn_sv(10);
-ok $warn =~ /^10 at $0 line /;
+ok $warn =~ /^10 at \Q$0\E line /;
 
 undef $warn;
 Devel::PPPort::warn_sv('');
-ok $warn =~ /^ at $0 line /;
+ok $warn =~ /^ at \Q$0\E line /;
 
 undef $warn;
 Devel::PPPort::warn_sv("\xE1");
-ok $warn =~ /^\xE1 at $0 line /;
+ok $warn =~ /^\xE1 at \Q$0\E line /;
 
 undef $warn;
 Devel::PPPort::warn_sv("\xC3\xA1");
-ok $warn =~ /^\xC3\xA1 at $0 line /;
+ok $warn =~ /^\xC3\xA1 at \Q$0\E line /;
 
 ok Devel::PPPort::mess_sv("\xE1\n", 0), "\xE1\n";
 ok Devel::PPPort::mess_sv(do {my $tmp = "\xE1\n"}, 1), "\xE1\n";
 
-ok Devel::PPPort::mess_sv(10, 0) =~ /^10 at $0 line /;
-ok Devel::PPPort::mess_sv(do {my $tmp = 10}, 1) =~ /^10 at $0 line /;
+ok Devel::PPPort::mess_sv(10, 0) =~ /^10 at \Q$0\E line /;
+ok Devel::PPPort::mess_sv(do {my $tmp = 10}, 1) =~ /^10 at \Q$0\E line /;
 
-ok Devel::PPPort::mess_sv('', 0) =~ /^ at $0 line /;
-ok Devel::PPPort::mess_sv(do {my $tmp = ''}, 1) =~ /^ at $0 line /;
+ok Devel::PPPort::mess_sv('', 0) =~ /^ at \Q$0\E line /;
+ok Devel::PPPort::mess_sv(do {my $tmp = ''}, 1) =~ /^ at \Q$0\E line /;
 
-ok Devel::PPPort::mess_sv("\xE1", 0) =~ /^\xE1 at $0 line /;
-ok Devel::PPPort::mess_sv(do {my $tmp = "\xE1"}, 1) =~ /^\xE1 at $0 line /;
+ok Devel::PPPort::mess_sv("\xE1", 0) =~ /^\xE1 at \Q$0\E line /;
+ok Devel::PPPort::mess_sv(do {my $tmp = "\xE1"}, 1) =~ /^\xE1 at \Q$0\E line /;
 
-ok Devel::PPPort::mess_sv("\xC3\xA1", 0) =~ /^\xC3\xA1 at $0 line /;
-ok Devel::PPPort::mess_sv(do {my $tmp = "\xC3\xA1"}, 1) =~ /^\xC3\xA1 at $0 line /;
+ok Devel::PPPort::mess_sv("\xC3\xA1", 0) =~ /^\xC3\xA1 at \Q$0\E line /;
+ok Devel::PPPort::mess_sv(do {my $tmp = "\xC3\xA1"}, 1) =~ /^\xC3\xA1 at \Q$0\E line /;
 
 if ("$]" >= '5.006') {
     BEGIN { if ("$]" >= '5.006' && "$]" < '5.008') { require utf8; utf8->import(); } }
@@ -454,12 +454,12 @@ if ("$]" >= '5.006') {
     undef $die;
     ok !defined eval { Devel::PPPort::croak_sv("\x{100}") };
     if ("$]" < '5.007001' || "$]" > '5.007003') {
-        ok $@ =~ /^\x{100} at $0 line /;
+        ok $@ =~ /^\x{100} at \Q$0\E line /;
     } else {
         skip 'skip: broken utf8 support in die hook', 0;
     }
     if ("$]" < '5.007001' || "$]" > '5.008') {
-        ok $die =~ /^\x{100} at $0 line /;
+        ok $die =~ /^\x{100} at \Q$0\E line /;
     } else {
         skip 'skip: broken utf8 support in die hook', 0;
     }
@@ -471,7 +471,7 @@ if ("$]" >= '5.006') {
 
         undef $warn;
         Devel::PPPort::warn_sv("\x{100}");
-        ok (my $tmp = $warn) =~ /^\x{100} at $0 line /;
+        ok (my $tmp = $warn) =~ /^\x{100} at \Q$0\E line /;
     } else {
         for (1..2) {
             skip 'skip: broken utf8 support in warn hook', 0;
@@ -481,8 +481,8 @@ if ("$]" >= '5.006') {
     ok Devel::PPPort::mess_sv("\x{100}\n", 0), "\x{100}\n";
     ok Devel::PPPort::mess_sv(do {my $tmp = "\x{100}\n"}, 1), "\x{100}\n";
 
-    ok Devel::PPPort::mess_sv("\x{100}", 0) =~ /^\x{100} at $0 line /;
-    ok Devel::PPPort::mess_sv(do {my $tmp = "\x{100}"}, 1) =~ /^\x{100} at $0 line /;
+    ok Devel::PPPort::mess_sv("\x{100}", 0) =~ /^\x{100} at \Q$0\E line /;
+    ok Devel::PPPort::mess_sv(do {my $tmp = "\x{100}"}, 1) =~ /^\x{100} at \Q$0\E line /;
 } else {
     for (1..12) {
         skip 'skip: no utf8 support', 0;
@@ -504,8 +504,8 @@ if (ord('A') != 65) {
 
     undef $die;
     ok !defined eval { Devel::PPPort::croak_sv(eval '"\N{U+E1}"') };
-    ok $@ =~ /^\xE1 at $0 line /;
-    ok $die =~ /^\xE1 at $0 line /;
+    ok $@ =~ /^\xE1 at \Q$0\E line /;
+    ok $die =~ /^\xE1 at \Q$0\E line /;
 
     {
         undef $die;
@@ -517,7 +517,7 @@ if (ord('A') != 65) {
 
     {
         undef $die;
-        my $expect = eval 'qr/^\N{U+C3}\N{U+A1} at $0 line /';
+        my $expect = eval 'qr/^\N{U+C3}\N{U+A1} at \Q$0\E line /';
         ok !defined eval { Devel::PPPort::croak_sv("\xC3\xA1") };
         ok $@ =~ $expect;
         ok $die =~ $expect;
@@ -529,7 +529,7 @@ if (ord('A') != 65) {
 
     undef $warn;
     Devel::PPPort::warn_sv(eval '"\N{U+E1}"');
-    ok $warn =~ /^\xE1 at $0 line /;
+    ok $warn =~ /^\xE1 at \Q$0\E line /;
 
     undef $warn;
     Devel::PPPort::warn_sv("\xC3\xA1\n");
@@ -537,7 +537,7 @@ if (ord('A') != 65) {
 
     undef $warn;
     Devel::PPPort::warn_sv("\xC3\xA1");
-    ok $warn =~ eval 'qr/^\N{U+C3}\N{U+A1} at $0 line /';
+    ok $warn =~ eval 'qr/^\N{U+C3}\N{U+A1} at \Q$0\E line /';
 
     if ("$]" < '5.004') {
         for (1..8) {
@@ -548,14 +548,14 @@ if (ord('A') != 65) {
       ok Devel::PPPort::mess_sv(eval('"\N{U+E1}\n"'), 0), eval '"\N{U+E1}\n"';
       ok Devel::PPPort::mess_sv(do {my $tmp = eval '"\N{U+E1}\n"'}, 1), eval '"\N{U+E1}\n"';
 
-      ok Devel::PPPort::mess_sv(eval('"\N{U+E1}"'), 0) =~ eval 'qr/^\N{U+E1} at $0 line /';
-      ok Devel::PPPort::mess_sv(do {my $tmp = eval '"\N{U+E1}"'}, 1) =~ eval 'qr/^\N{U+E1} at $0 line /';
+      ok Devel::PPPort::mess_sv(eval('"\N{U+E1}"'), 0) =~ eval 'qr/^\N{U+E1} at \Q$0\E line /';
+      ok Devel::PPPort::mess_sv(do {my $tmp = eval '"\N{U+E1}"'}, 1) =~ eval 'qr/^\N{U+E1} at \Q$0\E line /';
 
       ok Devel::PPPort::mess_sv("\xC3\xA1\n", 0), eval '"\N{U+C3}\N{U+A1}\n"';
       ok Devel::PPPort::mess_sv(do {my $tmp = "\xC3\xA1\n"}, 1), eval '"\N{U+C3}\N{U+A1}\n"';
 
-      ok Devel::PPPort::mess_sv("\xC3\xA1", 0) =~ eval 'qr/^\N{U+C3}\N{U+A1} at $0 line /';
-      ok Devel::PPPort::mess_sv(do {my $tmp = "\xC3\xA1"}, 1) =~ eval 'qr/^\N{U+C3}\N{U+A1} at $0 line /';
+      ok Devel::PPPort::mess_sv("\xC3\xA1", 0) =~ eval 'qr/^\N{U+C3}\N{U+A1} at \Q$0\E line /';
+      ok Devel::PPPort::mess_sv(do {my $tmp = "\xC3\xA1"}, 1) =~ eval 'qr/^\N{U+C3}\N{U+A1} at \Q$0\E line /';
     }
 } else {
     for (1..24) {
@@ -590,10 +590,10 @@ if ("$]" >= '5.007003' or ("$]" >= '5.006001' and "$]" < '5.007')) {
 }
 
 ok !defined eval { Devel::PPPort::croak_no_modify() };
-ok $@ =~ /^Modification of a read-only value attempted at $0 line /;
+ok $@ =~ /^Modification of a read-only value attempted at \Q$0\E line /;
 
 ok !defined eval { Devel::PPPort::croak_memory_wrap() };
-ok $@ =~ /^panic: memory wrap at $0 line /;
+ok $@ =~ /^panic: memory wrap at \Q$0\E line /;
 
 ok !defined eval { Devel::PPPort::croak_xs_usage("params") };
-ok $@ =~ /^Usage: Devel::PPPort::croak_xs_usage\(params\) at $0 line /;
+ok $@ =~ /^Usage: Devel::PPPort::croak_xs_usage\(params\) at \Q$0\E line /;

--- a/t/mess.t
+++ b/t/mess.t
@@ -72,8 +72,8 @@ ok $die, "\xE1\n";
 
 undef $die;
 ok !defined eval { Devel::PPPort::croak_sv(10) };
-ok $@ =~ /^10 at $0 line /;
-ok $die =~ /^10 at $0 line /;
+ok $@ =~ /^10 at \Q$0\E line /;
+ok $die =~ /^10 at \Q$0\E line /;
 
 undef $die;
 $@ = 'should not be visible (1)';
@@ -81,8 +81,8 @@ ok !defined eval {
     $@ = 'should not be visible (2)';
     Devel::PPPort::croak_sv('');
 };
-ok $@ =~ /^ at $0 line /;
-ok $die =~ /^ at $0 line /;
+ok $@ =~ /^ at \Q$0\E line /;
+ok $die =~ /^ at \Q$0\E line /;
 
 undef $die;
 $@ = 'should not be visible';
@@ -90,8 +90,8 @@ ok !defined eval {
     $@ = 'this must be visible';
     Devel::PPPort::croak_sv($@)
 };
-ok $@ =~ /^this must be visible at $0 line /;
-ok $die =~ /^this must be visible at $0 line /;
+ok $@ =~ /^this must be visible at \Q$0\E line /;
+ok $die =~ /^this must be visible at \Q$0\E line /;
 
 undef $die;
 $@ = 'should not be visible';
@@ -108,8 +108,8 @@ ok !defined eval {
     $@ = 'this must be visible';
     Devel::PPPort::croak_sv_errsv()
 };
-ok $@ =~ /^this must be visible at $0 line /;
-ok $die =~ /^this must be visible at $0 line /;
+ok $@ =~ /^this must be visible at \Q$0\E line /;
+ok $die =~ /^this must be visible at \Q$0\E line /;
 
 undef $die;
 $@ = 'should not be visible';
@@ -127,18 +127,18 @@ ok Devel::PPPort::get_counter(), 1;
 
 undef $die;
 ok !defined eval { Devel::PPPort::croak_sv('') };
-ok $@ =~ /^ at $0 line /;
-ok $die =~ /^ at $0 line /;
+ok $@ =~ /^ at \Q$0\E line /;
+ok $die =~ /^ at \Q$0\E line /;
 
 undef $die;
 ok !defined eval { Devel::PPPort::croak_sv("\xE1") };
-ok $@ =~ /^\xE1 at $0 line /;
-ok $die =~ /^\xE1 at $0 line /;
+ok $@ =~ /^\xE1 at \Q$0\E line /;
+ok $die =~ /^\xE1 at \Q$0\E line /;
 
 undef $die;
 ok !defined eval { Devel::PPPort::croak_sv("\xC3\xA1") };
-ok $@ =~ /^\xC3\xA1 at $0 line /;
-ok $die =~ /^\xC3\xA1 at $0 line /;
+ok $@ =~ /^\xC3\xA1 at \Q$0\E line /;
+ok $die =~ /^\xC3\xA1 at \Q$0\E line /;
 
 undef $warn;
 Devel::PPPort::warn_sv("\xE1\n");
@@ -146,34 +146,34 @@ ok $warn, "\xE1\n";
 
 undef $warn;
 Devel::PPPort::warn_sv(10);
-ok $warn =~ /^10 at $0 line /;
+ok $warn =~ /^10 at \Q$0\E line /;
 
 undef $warn;
 Devel::PPPort::warn_sv('');
-ok $warn =~ /^ at $0 line /;
+ok $warn =~ /^ at \Q$0\E line /;
 
 undef $warn;
 Devel::PPPort::warn_sv("\xE1");
-ok $warn =~ /^\xE1 at $0 line /;
+ok $warn =~ /^\xE1 at \Q$0\E line /;
 
 undef $warn;
 Devel::PPPort::warn_sv("\xC3\xA1");
-ok $warn =~ /^\xC3\xA1 at $0 line /;
+ok $warn =~ /^\xC3\xA1 at \Q$0\E line /;
 
 ok Devel::PPPort::mess_sv("\xE1\n", 0), "\xE1\n";
 ok Devel::PPPort::mess_sv(do {my $tmp = "\xE1\n"}, 1), "\xE1\n";
 
-ok Devel::PPPort::mess_sv(10, 0) =~ /^10 at $0 line /;
-ok Devel::PPPort::mess_sv(do {my $tmp = 10}, 1) =~ /^10 at $0 line /;
+ok Devel::PPPort::mess_sv(10, 0) =~ /^10 at \Q$0\E line /;
+ok Devel::PPPort::mess_sv(do {my $tmp = 10}, 1) =~ /^10 at \Q$0\E line /;
 
-ok Devel::PPPort::mess_sv('', 0) =~ /^ at $0 line /;
-ok Devel::PPPort::mess_sv(do {my $tmp = ''}, 1) =~ /^ at $0 line /;
+ok Devel::PPPort::mess_sv('', 0) =~ /^ at \Q$0\E line /;
+ok Devel::PPPort::mess_sv(do {my $tmp = ''}, 1) =~ /^ at \Q$0\E line /;
 
-ok Devel::PPPort::mess_sv("\xE1", 0) =~ /^\xE1 at $0 line /;
-ok Devel::PPPort::mess_sv(do {my $tmp = "\xE1"}, 1) =~ /^\xE1 at $0 line /;
+ok Devel::PPPort::mess_sv("\xE1", 0) =~ /^\xE1 at \Q$0\E line /;
+ok Devel::PPPort::mess_sv(do {my $tmp = "\xE1"}, 1) =~ /^\xE1 at \Q$0\E line /;
 
-ok Devel::PPPort::mess_sv("\xC3\xA1", 0) =~ /^\xC3\xA1 at $0 line /;
-ok Devel::PPPort::mess_sv(do {my $tmp = "\xC3\xA1"}, 1) =~ /^\xC3\xA1 at $0 line /;
+ok Devel::PPPort::mess_sv("\xC3\xA1", 0) =~ /^\xC3\xA1 at \Q$0\E line /;
+ok Devel::PPPort::mess_sv(do {my $tmp = "\xC3\xA1"}, 1) =~ /^\xC3\xA1 at \Q$0\E line /;
 
 if ("$]" >= '5.006') {
     BEGIN { if ("$]" >= '5.006' && "$]" < '5.008') { require utf8; utf8->import(); } }
@@ -194,12 +194,12 @@ if ("$]" >= '5.006') {
     undef $die;
     ok !defined eval { Devel::PPPort::croak_sv("\x{100}") };
     if ("$]" < '5.007001' || "$]" > '5.007003') {
-        ok $@ =~ /^\x{100} at $0 line /;
+        ok $@ =~ /^\x{100} at \Q$0\E line /;
     } else {
         skip 'skip: broken utf8 support in die hook', 0;
     }
     if ("$]" < '5.007001' || "$]" > '5.008') {
-        ok $die =~ /^\x{100} at $0 line /;
+        ok $die =~ /^\x{100} at \Q$0\E line /;
     } else {
         skip 'skip: broken utf8 support in die hook', 0;
     }
@@ -211,7 +211,7 @@ if ("$]" >= '5.006') {
 
         undef $warn;
         Devel::PPPort::warn_sv("\x{100}");
-        ok (my $tmp = $warn) =~ /^\x{100} at $0 line /;
+        ok (my $tmp = $warn) =~ /^\x{100} at \Q$0\E line /;
     } else {
         for (1..2) {
             skip 'skip: broken utf8 support in warn hook', 0;
@@ -221,8 +221,8 @@ if ("$]" >= '5.006') {
     ok Devel::PPPort::mess_sv("\x{100}\n", 0), "\x{100}\n";
     ok Devel::PPPort::mess_sv(do {my $tmp = "\x{100}\n"}, 1), "\x{100}\n";
 
-    ok Devel::PPPort::mess_sv("\x{100}", 0) =~ /^\x{100} at $0 line /;
-    ok Devel::PPPort::mess_sv(do {my $tmp = "\x{100}"}, 1) =~ /^\x{100} at $0 line /;
+    ok Devel::PPPort::mess_sv("\x{100}", 0) =~ /^\x{100} at \Q$0\E line /;
+    ok Devel::PPPort::mess_sv(do {my $tmp = "\x{100}"}, 1) =~ /^\x{100} at \Q$0\E line /;
 } else {
     for (1..12) {
         skip 'skip: no utf8 support', 0;
@@ -244,8 +244,8 @@ if (ord('A') != 65) {
 
     undef $die;
     ok !defined eval { Devel::PPPort::croak_sv(eval '"\N{U+E1}"') };
-    ok $@ =~ /^\xE1 at $0 line /;
-    ok $die =~ /^\xE1 at $0 line /;
+    ok $@ =~ /^\xE1 at \Q$0\E line /;
+    ok $die =~ /^\xE1 at \Q$0\E line /;
 
     {
         undef $die;
@@ -257,7 +257,7 @@ if (ord('A') != 65) {
 
     {
         undef $die;
-        my $expect = eval 'qr/^\N{U+C3}\N{U+A1} at $0 line /';
+        my $expect = eval 'qr/^\N{U+C3}\N{U+A1} at \Q$0\E line /';
         ok !defined eval { Devel::PPPort::croak_sv("\xC3\xA1") };
         ok $@ =~ $expect;
         ok $die =~ $expect;
@@ -269,7 +269,7 @@ if (ord('A') != 65) {
 
     undef $warn;
     Devel::PPPort::warn_sv(eval '"\N{U+E1}"');
-    ok $warn =~ /^\xE1 at $0 line /;
+    ok $warn =~ /^\xE1 at \Q$0\E line /;
 
     undef $warn;
     Devel::PPPort::warn_sv("\xC3\xA1\n");
@@ -277,7 +277,7 @@ if (ord('A') != 65) {
 
     undef $warn;
     Devel::PPPort::warn_sv("\xC3\xA1");
-    ok $warn =~ eval 'qr/^\N{U+C3}\N{U+A1} at $0 line /';
+    ok $warn =~ eval 'qr/^\N{U+C3}\N{U+A1} at \Q$0\E line /';
 
     if ("$]" < '5.004') {
         for (1..8) {
@@ -288,14 +288,14 @@ if (ord('A') != 65) {
       ok Devel::PPPort::mess_sv(eval('"\N{U+E1}\n"'), 0), eval '"\N{U+E1}\n"';
       ok Devel::PPPort::mess_sv(do {my $tmp = eval '"\N{U+E1}\n"'}, 1), eval '"\N{U+E1}\n"';
 
-      ok Devel::PPPort::mess_sv(eval('"\N{U+E1}"'), 0) =~ eval 'qr/^\N{U+E1} at $0 line /';
-      ok Devel::PPPort::mess_sv(do {my $tmp = eval '"\N{U+E1}"'}, 1) =~ eval 'qr/^\N{U+E1} at $0 line /';
+      ok Devel::PPPort::mess_sv(eval('"\N{U+E1}"'), 0) =~ eval 'qr/^\N{U+E1} at \Q$0\E line /';
+      ok Devel::PPPort::mess_sv(do {my $tmp = eval '"\N{U+E1}"'}, 1) =~ eval 'qr/^\N{U+E1} at \Q$0\E line /';
 
       ok Devel::PPPort::mess_sv("\xC3\xA1\n", 0), eval '"\N{U+C3}\N{U+A1}\n"';
       ok Devel::PPPort::mess_sv(do {my $tmp = "\xC3\xA1\n"}, 1), eval '"\N{U+C3}\N{U+A1}\n"';
 
-      ok Devel::PPPort::mess_sv("\xC3\xA1", 0) =~ eval 'qr/^\N{U+C3}\N{U+A1} at $0 line /';
-      ok Devel::PPPort::mess_sv(do {my $tmp = "\xC3\xA1"}, 1) =~ eval 'qr/^\N{U+C3}\N{U+A1} at $0 line /';
+      ok Devel::PPPort::mess_sv("\xC3\xA1", 0) =~ eval 'qr/^\N{U+C3}\N{U+A1} at \Q$0\E line /';
+      ok Devel::PPPort::mess_sv(do {my $tmp = "\xC3\xA1"}, 1) =~ eval 'qr/^\N{U+C3}\N{U+A1} at \Q$0\E line /';
     }
 } else {
     for (1..24) {
@@ -330,11 +330,11 @@ if ("$]" >= '5.007003' or ("$]" >= '5.006001' and "$]" < '5.007')) {
 }
 
 ok !defined eval { Devel::PPPort::croak_no_modify() };
-ok $@ =~ /^Modification of a read-only value attempted at $0 line /;
+ok $@ =~ /^Modification of a read-only value attempted at \Q$0\E line /;
 
 ok !defined eval { Devel::PPPort::croak_memory_wrap() };
-ok $@ =~ /^panic: memory wrap at $0 line /;
+ok $@ =~ /^panic: memory wrap at \Q$0\E line /;
 
 ok !defined eval { Devel::PPPort::croak_xs_usage("params") };
-ok $@ =~ /^Usage: Devel::PPPort::croak_xs_usage\(params\) at $0 line /;
+ok $@ =~ /^Usage: Devel::PPPort::croak_xs_usage\(params\) at \Q$0\E line /;
 


### PR DESCRIPTION
This seems to happen only when Devel::PPPort was built with
Visual C++ and nmake as a standalone distribution.

perl/perl5@1ddd2f5fcd8802a45ffd773aec3af107f37613f6 had fixed that
before, but the change was made only in the autogenerated test file
and it was discarded when the tests were regenerated.