### PR TITLE
Fix t/ppphtest.t for Perl versions prior to 5.6.0

### DIFF
--- a/parts/inc/ppphbin
+++ b/parts/inc/ppphbin
@@ -15,6 +15,8 @@
 
 use strict;
 
+BEGIN { require warnings if "$]" > '5.006' }
+
 # Disable broken TRIE-optimization
 BEGIN { eval '${^RE_TRIE_MAXBUF} = -1' if "$]" >= 5.009004 && "$]" <= 5.009005 }
 
@@ -115,8 +117,8 @@ my($hint, $define, $function);
 
 sub find_api
 {
+  BEGIN { 'warnings'->unimport('uninitialized') if "$]" > '5.006' }
   my $code = shift;
-  no warnings 'uninitialized';
   $code =~ s{
     / (?: \*[^*]*\*+(?:[^$ccs][^*]*\*+)* / | /[^\r\n]*)
   | "[^"\\]*(?:\\.[^"\\]*)*"


### PR DESCRIPTION
Module warnings.pm is not available for these old versions.