### PR TITLE
D:P: Make sure WIDEST_UTYPE is unsigned

### DIFF
--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -353,7 +353,7 @@ typedef OP* (CPERLscope(*Perl_check_t)) (pTHX_ OP*);
 #  ifdef U64TYPE
 #   define WIDEST_UTYPE U64TYPE
 #  else
-#   define WIDEST_UTYPE Quad_t
+#   define WIDEST_UTYPE unsigned Quad_t
 #  endif
 # else
 #  define WIDEST_UTYPE U32


### PR DESCRIPTION
In some platforms and configurations, it was getting 'signed'

Diagnosed by pali++