### PR TITLE
Setup D_PPP_RELEASE_DATE on dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+*.swp
+*.bak
+*~
+*.old
+*.tar.gz
+*.tar
+*.ERR
+*.orig
+*.rej
+cover_db/
+TODO
 /blib/
 /Makefile
 /Makefile.old

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -147,6 +147,8 @@ sub MY::postamble
   my $post = shift->SUPER::postamble(@_);
   $post .= <<'POSTAMBLE';
 
+.PHONY: purge_all regen_pm regen_xs regen_tests regen_h regen_release_date
+
 purge_all: realclean
 	@$(RM_F) PPPort.pm t/*.t
 
@@ -162,7 +164,10 @@ regen_tests:
 regen_h:
 	$(PERL) -I$(INST_ARCHLIB) -I$(INST_LIB) -I$(PERL_ARCHLIB) -I$(PERL_LIB) ppport_h.PL
 
-regen: regen_pm regen_xs regen_tests regen_h
+regen_release_date:
+	$(PERL) -I$(INST_ARCHLIB) -I$(INST_LIB) -I$(PERL_ARCHLIB) -I$(PERL_LIB) devel/update_release_date.pl
+
+regen: regen_pm regen_xs regen_tests regen_h regen_release_date
 
 POSTAMBLE
   return $post;
@@ -234,7 +239,7 @@ sub MY::dist_core
   my $rule;
   foreach $rule ( @rules ) {
     if ( $rule =~ m{^\s*^dist\s+:}m ) {
-        $rule =~ s{:}{: PPPort.pm manifest}; # make sure we update PPPort.pm
+        $rule =~ s{:}{: PPPort.pm manifest regen}; # make sure we update PPPort.pm
         $rule .= qq[\t].q[$(NOECHO) $(ECHO) "Warning: Please check '__MAX_PERL__' value in PPPort_pm.PL"].qq[\n];
         # checking that the tarball has no Pax Header - avoid false positives by using [P]axHEader
         $rule .= qq[\t].q[$(NOECHO) zgrep -a -e '[P]axHeader' $(DISTVNAME).tar$(SUFFIX) && ( $(ECHO) "ERROR: Pax Header detected in tarball"; rm -f $(DISTVNAME).tar$(SUFFIX) ) ||:].qq[\n];

--- a/devel/update_release_date.pl
+++ b/devel/update_release_date.pl
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use FindBin;
+
+exit( run(@ARGV) || 0 ) unless caller;
+
+sub run {
+    my $now = time();
+
+    my $a_day = 86_400;
+    my $today = $now - $now % $a_day;
+
+    my ( $sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst ) =
+      gmtime($today);
+    ++$mon;
+    $year += 1_900;
+
+    my $human_ts = sprintf( "%04d-%02d-%02d", $year, $mon, $mday );
+
+    print qq[# Updating D_PPP_RELEASE_DATE timestamp to $today /* $human_ts */\n];
+
+    my $f             = q[parts/inc/version];
+    my $file_to_patch = $FindBin::Bin . '/../' . $f;
+    die "Cannot find $f: $!" unless -e $file_to_patch;
+
+    my $content;
+    {
+        local $/;
+        open( my $fh, '<', $file_to_patch );
+        $content = <$fh>;
+    }
+
+    $content =~
+      s{^(\#\s*define\s+D_PPP_RELEASE_DATE)\b.*$}{$1 $today /* $human_ts */}m
+      or die "Cannot find D_PPP_RELEASE_DATE pattern in file $f";
+
+    {
+        local $/;
+        open( my $fh, '>', $file_to_patch );
+        print {$fh} $content;
+    }
+
+    print qq[$f patched with D_PPP_RELEASE_DATE\n];
+
+    return;
+}
+
+1;

--- a/parts/inc/version
+++ b/parts/inc/version
@@ -25,6 +25,8 @@ PERL_PATCHLEVEL_H_IMPLICIT
 
 =implementation
 
+#define D_PPP_RELEASE_DATE 1596672000 /* 2020-08-06 */
+
 #if ! defined(PERL_REVISION) && ! defined(PERL_VERSION_MAJOR)
 #  if   !   defined(__PATCHLEVEL_H_INCLUDED__)                                  \
      && ! ( defined(PATCHLEVEL) && defined(SUBVERSION))


### PR DESCRIPTION
When running make regen_release_date which
is trigger as part of make regen or make dist
we are updating parts/inc/version with the
current timestamp for the day.

This commits setup the build timestamp but nothing
is consuming it yet at this point.