### PR TITLE
Fix warning croak_xs_usage redefined

### DIFF
--- a/parts/inc/mess
+++ b/parts/inc/mess
@@ -228,6 +228,7 @@ croak_xs_usage(const CV *const cv, const char *const params)
         croak("Usage: CODE(0x%" UVxf ")(%s)", PTR2UV(cv), params);
     }
 }
+#undef  croak_xs_usage
 #endif
 #endif
 


### PR DESCRIPTION
This is fixing a warning from RealPPPort.c
as described in #194.