### PR TITLE
Define PERL_ARGS_ASSERT_CROAK_XS_USAGE when setting croak_xs_usage

### DIFF
--- a/parts/inc/mess
+++ b/parts/inc/mess
@@ -200,7 +200,8 @@ mess_sv(pTHX_ SV *basemsg, bool consume)
 
 #ifndef croak_xs_usage
 #if { NEED croak_xs_usage }
-
+#ifndef PERL_ARGS_ASSERT_CROAK_XS_USAGE
+#define PERL_ARGS_ASSERT_CROAK_XS_USAGE assert(cv); assert(params)
 
 void
 croak_xs_usage(const CV *const cv, const char *const params)
@@ -208,11 +209,7 @@ croak_xs_usage(const CV *const cv, const char *const params)
     dTHX;
     const GV *const gv = CvGV(cv);
 
-#ifdef PERL_ARGS_ASSERT_CROAK_XS_USAGE
     PERL_ARGS_ASSERT_CROAK_XS_USAGE;
-#else
-     assert(cv); assert(params);
-#endif
 
     if (gv) {
         const char *const gvname = GvNAME(gv);
@@ -228,6 +225,7 @@ croak_xs_usage(const CV *const cv, const char *const params)
         croak("Usage: CODE(0x%" UVxf ")(%s)", PTR2UV(cv), params);
     }
 }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
This is matching what's done in ExtUtils::ParseXS::Utilities
and avoids to redefine croak_xs_usage later.

References: #194