### PR TITLE
.PHONY is specific to Unix make utilities.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -149,10 +149,12 @@ sub configure
 sub MY::postamble
 {
   package MY;
+  use Config;
   my $post = shift->SUPER::postamble(@_);
+  # .PHONY is a syntax error in MMK/MMS
+  my $phony = ($Config{make} =~ m/MM(K|S)/) ? 'PHONY' : '.PHONY';
+  $post .= "\n\n${phony}: purge_all regen_pm regen_xs regen_tests regen_h regen_release_date\n\n";
   $post .= <<'POSTAMBLE';
-
-.PHONY: purge_all regen_pm regen_xs regen_tests regen_h regen_release_date
 
 purge_all: realclean
 	@$(RM_F) PPPort.pm t/*.t


### PR DESCRIPTION
And in MMS or MMK on VMS it's a syntax error.  So only spell it
with a dot when not using those utilities to run Devel::PPPort's
Makefile.PL.

(cherry picked from commit b6efc7071950ca9585eb17fc358efaee5df1ff14)
Signed-off-by: Nicolas R <atoomic@cpan.org>