### PR TITLE
Fix scanprov

### DIFF
--- a/devel/scanprov
+++ b/devel/scanprov
@@ -347,7 +347,7 @@ sub find_first_mentions
                     else {
                         foreach my $define (keys %defines) {
                             # Don't override input 'M' symbols.
-                            $remaining{$define} = $new_code
+                            $remaining{$define} = 'Z'
                                             unless defined $remaining{$define};
                         }
                     }


### PR DESCRIPTION
Commit 622fbe37e275776fe46e650d84b84a946bc46931 rearranged this loop,
but forgot to remove the use of the `$new_code` variable.