### PR TITLE
Remove C `register` declarations

### DIFF
--- a/parts/inc/cop
+++ b/parts/inc/cop
@@ -57,7 +57,7 @@ DPPP_dopoptosub_at(const PERL_CONTEXT *cxstk, I32 startingblock)
     I32 i;
 
     for (i = startingblock; i >= 0; i--) {
-	register const PERL_CONTEXT * const cx = &cxstk[i];
+	const PERL_CONTEXT * const cx = &cxstk[i];
 	switch (CxTYPE(cx)) {
 	default:
 	    continue;
@@ -76,9 +76,9 @@ DPPP_dopoptosub_at(const PERL_CONTEXT *cxstk, I32 startingblock)
 const PERL_CONTEXT *
 caller_cx(pTHX_ I32 level, const PERL_CONTEXT **dbcxp)
 {
-    register I32 cxix = DPPP_dopoptosub_at(cxstack, cxstack_ix);
-    register const PERL_CONTEXT *cx;
-    register const PERL_CONTEXT *ccstack = cxstack;
+    I32 cxix = DPPP_dopoptosub_at(cxstack, cxstack_ix);
+    const PERL_CONTEXT *cx;
+    const PERL_CONTEXT *ccstack = cxstack;
     const PERL_SI *top_si = PL_curstackinfo;
 
     for (;;) {

--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -302,7 +302,7 @@ __UNDEFINED__  dITEMS          I32 items = SP - MARK
 __UNDEFINED__  dXSTARG         SV * targ = sv_newmortal()
 
 __UNDEFINED__  dAXMARK         I32 ax = POPMARK; \
-                               register SV ** const mark = PL_stack_base + ax++
+                               SV ** const mark = PL_stack_base + ax++
 
 
 __UNDEFINED__  XSprePUSH       (sp = PL_stack_base + ax - 1)


### PR DESCRIPTION
These were removed from Perl in
https://github.com/perl/perl5/commit/eb578fdb5569b91c28466a4d1939e381ff6ceaf4,
let's remove them from here as well.