### PR TITLE
The utf8_to_uvchr_buf implementation misses a NULL check in one place.

### DIFF
--- a/parts/inc/utf8
+++ b/parts/inc/utf8
@@ -359,7 +359,9 @@ utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
          * disabled, so this 'if' will be true, and so later on, we know that
          * 's' is dereferencible */
         if (do_warnings) {
-            *retlen = (STRLEN) -1;
+            if (retlen) {
+                *retlen = (STRLEN) -1;
+            }
         }
         else {
             ret = D_PPP_utf8_to_uvchr_buf_callee(


### PR DESCRIPTION
strlen might be NULL - the code needs to check this before attempting to assign to it. This case is hit by one of Data::Dumper's regression tests.