### PR TITLE
Devel::PPPort: Fix STMT_START { ... } STMT_END

### DIFF
--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -286,7 +286,7 @@ __UNDEF_NOT_PROVIDED__  PERL_GCC_BRACE_GROUPS_FORBIDDEN
 
 #undef STMT_START
 #undef STMT_END
-#ifdef PERL_USE_GCC_BRACE_GROUPS
+#if defined(VOIDFLAGS) && defined(PERL_USE_GCC_BRACE_GROUPS)
 #  define STMT_START    (void)( /* gcc supports ``({ STATEMENTS; })'' */
 #  define STMT_END      )
 #else


### PR DESCRIPTION
This fixes up 6d66b125bb339b62c0d8d4283d3fe576795764ce so that the
Devel::PPPort portion works on all supported Perls.

Basically, we have to preserve the pre-existing behavior for all Perls
that still have VOIDFLAGS, which was removed by:

Author: Nicholas Clark nick@ccl4.org
Date: Wed Sep 11 11:54:42 2013 +0200

Eliminate the only use of VOIDFLAGS, as part of STMT_START in perl.h

STMT_START has used VOIDFLAGS as part of its conditional compilation
since it was added by commit 728e280 (March 1996). The code originally
read:

/* Now which other defined()s do we need here ??? */

Since then it has been amended to avoid entering that definition for GCC
on Solaris. Given that all current Solaris compilers are C89 conformant,
VOIDFLAGS will always be true (actually 15), so the test is redundant.
Even back in 1996, it's possible that VOIDFLAGS was always non-zero on
SunOS, rendering the test obsolete from the start.

Spotted by Brian Fraser, and extracted from a larger patch of his.

(cherry picked from commit 8a0214ab98bbdd4da29dcb1e76877b3d24788e2e)
Signed-off-by: Nicolas R <atoomic@cpan.org>