### PR TITLE
Fix utf8_to_uvchr_buf issue with Perl >= 5.35.9

### DIFF
--- a/parts/base/5035010
+++ b/parts/base/5035010
@@ -1,6 +1,15 @@
 5.035010
+ALIGNED_TYPE                   # Z added by devel/scanprov
+ALIGNED_TYPE_NAME              # Z added by devel/scanprov
 ASSERT_IS_LITERAL              # Z added by devel/scanprov
 ASSERT_IS_PTR                  # Z added by devel/scanprov
+copy_length                    # Z added by devel/scanprov
+del_body_by_type               # Z added by devel/scanprov
+FIT_ARENA                      # Z added by devel/scanprov
+FIT_ARENA0                     # Z added by devel/scanprov
+FIT_ARENAn                     # Z added by devel/scanprov
+HADNV                          # Z added by devel/scanprov
+HASARENA                       # Z added by devel/scanprov
 LOOKBEHIND_END                 # Z added by devel/scanprov
 LOOKBEHIND_END_t8              # Z added by devel/scanprov
 LOOKBEHIND_END_t8_p8           # Z added by devel/scanprov
@@ -8,10 +17,28 @@ LOOKBEHIND_END_t8_pb           # Z added by devel/scanprov
 LOOKBEHIND_END_tb              # Z added by devel/scanprov
 LOOKBEHIND_END_tb_p8           # Z added by devel/scanprov
 LOOKBEHIND_END_tb_pb           # Z added by devel/scanprov
+MEM_LOG_DEL_SV                 # Z added by devel/scanprov
+MEM_LOG_NEW_SV                 # Z added by devel/scanprov
+new_body_allocated             # Z added by devel/scanprov
+new_body_from_arena            # Z added by devel/scanprov
+new_NOARENA                    # Z added by devel/scanprov
+new_NOARENAZ                   # Z added by devel/scanprov
+new_SV                         # Z added by devel/scanprov
+newSV_type_mortal              # U
+new_XNV                        # Z added by devel/scanprov
+new_XPVMG                      # Z added by devel/scanprov
+new_XPVNV                      # Z added by devel/scanprov
+NOARENA                        # Z added by devel/scanprov
+NONV                           # Z added by devel/scanprov
+PERL_PV_ESCAPE_DWIM_ALL_HEX    # Z added by devel/scanprov
+POISON_SV_HEAD                 # Z added by devel/scanprov
 reg_la_NOTHING                 # F added by devel/scanprov
 reg_la_OPFAIL                  # F added by devel/scanprov
 REG_LB_SEEN                    # Z added by devel/scanprov
 regnode_guts_debug             # F added by devel/scanprov
+SvARENA_CHAIN                  # Z added by devel/scanprov
+SvARENA_CHAIN_SET              # Z added by devel/scanprov
 sv_len_utf8_nomg               # U (Perl_sv_len_utf8_nomg)
 SvPOK_or_cached_IV             # Z added by devel/scanprov
+uproot_SV                      # Z added by devel/scanprov
 UTF8_IS_REPLACEMENT            # U

--- a/parts/embed.fnc
+++ b/parts/embed.fnc
@@ -1519,7 +1519,8 @@ Apd	|SV*	|newSVrv	|NN SV *const rv|NULLOK const char *const classname
 ApMbdR	|SV*	|newSVsv	|NULLOK SV *const old
 AmdR	|SV*	|newSVsv_nomg	|NULLOK SV *const old
 AdpR	|SV*	|newSVsv_flags	|NULLOK SV *const old|I32 flags
-ApdR	|SV*	|newSV_type	|const svtype type
+ApdiR	|SV*	|newSV_type	|const svtype type
+ApdIR	|SV*    |newSV_type_mortal|const svtype type
 ApdR	|OP*	|newUNOP	|I32 type|I32 flags|NULLOK OP* first
 ApdR	|OP*	|newUNOP_AUX	|I32 type|I32 flags|NULLOK OP* first \
 				|NULLOK UNOP_AUX_item *aux
@@ -3171,7 +3172,7 @@ S	|STRLEN	|sv_pos_b2u_midway|NN const U8 *const s|NN const U8 *const target \
 S	|void	|assert_uft8_cache_coherent|NN const char *const func \
 		|STRLEN from_cache|STRLEN real|NN SV *const sv
 ST	|char *	|F0convert	|NV nv|NN char *const endbuf|NN STRLEN *const len
-S	|SV *	|more_sv
+Cp	|SV *	|more_sv
 S	|bool	|sv_2iuv_common	|NN SV *const sv
 S	|void	|glob_assign_glob|NN SV *const dsv|NN SV *const ssv \
 		|const int dtype
@@ -3180,7 +3181,7 @@ S	|void	|anonymise_cv_maybe	|NN GV *gv|NN CV *cv
 #endif
 
 : Used in sv.c and hv.c
-po	|void *	|more_bodies	|const svtype sv_type|const size_t body_size \
+Cpo	|void *	|more_bodies	|const svtype sv_type|const size_t body_size \
 				|const size_t arena_size
 EXpR	|SV*	|get_and_check_backslash_N_name|NN const char* s	\
 				|NN const char* e			\

--- a/parts/inc/utf8
+++ b/parts/inc/utf8
@@ -304,7 +304,7 @@ utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
     }
     else
 
-#    endif  /* < 5.26 */
+#      endif  /* < 5.26 */
 
         /* Here, we are either in a release that properly detects overflow, or
          * we have checked for overflow and the next statement is executing as
@@ -317,7 +317,7 @@ utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
                     s, curlen, retlen,   (UTF8_ALLOW_ANYUV
                                       & ~(UTF8_ALLOW_LONG|UTF8_ALLOW_EMPTY)));
 
-#    if { VERSION >= 5.26.0 } && { VERSION < 5.28.0 }
+#      if { VERSION >= 5.26.0 } && { VERSION < 5.28.0 }
 
     /* But actually, more modern versions restrict the UV to being no more than
      * what an IV can hold, so it could still have gotten it wrong about
@@ -326,7 +326,7 @@ utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
         overflows = 1;
     }
 
-#    endif
+#      endif
 
     if (UNLIKELY(overflows)) {
         if (! do_warnings) {
@@ -372,7 +372,7 @@ utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
              * modern version of this function returns */
             ret = UNICODE_REPLACEMENT;
 
-#    if { VERSION < 5.16.0 }
+#      if { VERSION < 5.16.0 }
 
             /* Versions earlier than this don't necessarily return the proper
              * length.  It should not extend past the end of string, nor past
@@ -384,11 +384,11 @@ utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
                 *retlen = D_PPP_MIN(*retlen, curlen);
                 *retlen = D_PPP_MIN(*retlen, UTF8SKIP(s));
                 do {
-#      ifdef UTF8_IS_CONTINUATION
+#        ifdef UTF8_IS_CONTINUATION
                     if (! UTF8_IS_CONTINUATION(s[i]))
-#      else       /* Versions without the above don't support EBCDIC anyway */
+#        else       /* Versions without the above don't support EBCDIC anyway */
                     if (s[i] < 0x80 || s[i] > 0xBF)
-#      endif
+#        endif
                     {
                         *retlen = i;
                         break;
@@ -396,7 +396,7 @@ utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
                 } while (++i < *retlen);
             }
 
-#    endif
+#      endif  /* end of < 5.16.0 */
 
         }
     }

--- a/parts/inc/utf8
+++ b/parts/inc/utf8
@@ -182,10 +182,10 @@ __UNDEFINED__ REPLACEMENT_CHARACTER_UTF8  "\xDD\x72\x72\x70"
 #  error Unknown character set
 #endif
 
-#if { VERSION < 5.31.4 }
-        /* Versions prior to this accepted things that are now considered
-         * malformations, and didn't return -1 on error with warnings enabled
-         * */
+#if { VERSION < 5.35.10 }
+        /* Versions prior to 5.31.4 accepted things that are now considered
+         * malformations, and didn't return -1 on error with warnings enabled.
+         * Versions before 5.35.10 dereferenced empty input without checking */
 #  undef utf8_to_uvchr_buf
 #endif
 
@@ -228,6 +228,34 @@ __UNDEFINED__ REPLACEMENT_CHARACTER_UTF8  "\xDD\x72\x72\x70"
 UV
 utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
 {
+#    if { VERSION >= 5.31.4 }   /* But from above, must be < 5.35.10 */
+#      if { VERSION != 5.35.9 }
+
+    /* Versions less than 5.35.9 could dereference s on zero length, so
+     * pass it something where no harm comes from that. */
+    if (send <= s) s = send = (U8 *) "?";
+    return Perl_utf8_to_uvchr_buf_helper(aTHX_ s, send, retlen);
+
+#      else /* Below is 5.35.9, which also works on non-empty input, but
+               for empty input, can wrongly dereference, and additionally is
+               also just plain broken */
+    if (send > s) return Perl_utf8_to_uvchr_buf_helper(aTHX_ s, send, retlen);
+    if (! ckWARN_d(WARN_UTF8)) {
+        if (retlen) *retlen = 0;
+        return UNICODE_REPLACEMENT;
+    }
+    else {
+        s = send = (U8 *) "?";
+
+        /* Call just for its warning */
+        (void) Perl__utf8n_to_uvchr_msgs_helper(s, 0, NULL, 0, NULL, NULL);
+        if (retlen) *retlen = (STRLEN) -1;
+        return 0;
+    }
+
+#      endif
+#    else
+
     UV ret;
     STRLEN curlen;
     bool overflows = 0;
@@ -249,7 +277,7 @@ utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
         }
     }
 
-#    if { VERSION < 5.26.0 } && ! defined(EBCDIC)
+#      if { VERSION < 5.26.0 } && ! defined(EBCDIC)
 
     /* Perl did not properly detect overflow for much of its history on
      * non-EBCDIC platforms, often returning an overlong value which may or may
@@ -402,6 +430,9 @@ utf8_to_uvchr_buf(pTHX_ const U8 *s, const U8 *send, STRLEN *retlen)
     }
 
     return ret;
+
+#    endif    /* end of < 5.31.4 */
+
 }
 
 #  endif

--- a/parts/todo/5035010
+++ b/parts/todo/5035010
@@ -1,2 +1,3 @@
 5.035010
+newSV_type_mortal              # U
 UTF8_IS_REPLACEMENT            # U


### PR DESCRIPTION
Closes #219

5.35.9 introduced a bug when called with an empty string.  It has been illegal to do this for some releases now, but it was legal for most of the lifespan of UTF-8, and D-PPPort has tested for it.  So on non-debugging builds, Perl behaves as it used to, returning that the input is malformed, and potentially raising an error.  But this is broken in blead at the moment.

In working on this problem, I found two instances in blead where it derefernces a string which is supposedly empty.  This bug dates at least to 5.31.4.

So these patches workaround two bugs in core Perl.
