### PR TITLE
parts/inc/misc: backport dNOOP change

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,11 +1,15 @@
 Revision history for Devel-PPPort
 
+NEXT
+
+ * Update dNOOP definition for Perl < 5.27.7
+
 3.67 - 2022-03-08
 
   * fix utf8.t with recent development versions of Perl
   * utf8_to_uvchr_buf: Workaround bugs in Perl (BBC)
-  - v5.35.9 was returning an incorrect value
-  - fix dereference empty string
+  * v5.35.9 was returning an incorrect value
+  * fix dereference empty string
 
 3.66 - 2022-03-02
 
@@ -32,7 +36,7 @@ Revision history for Devel-PPPort
   * Backport NOT_REACHED
   * Backport G_LIST
   * various internal changes
-  
+
 3.62 - 2020-10-16
   * Restore missing PPPort.pm
   * Fix metaCPAN indexing

--- a/parts/inc/misc
+++ b/parts/inc/misc
@@ -227,7 +227,11 @@ __UNDEFINED__ SvRXOK(sv) (!!SvRX(sv))
 #endif
 
 __UNDEFINED__  NOOP          /*EMPTY*/(void)0
-__UNDEFINED__  dNOOP         extern int /*@unused@*/ Perl___notused PERL_UNUSED_DECL
+
+#if { VERSION < 5.27.7 }
+#undef dNOOP
+__UNDEFINED__ dNOOP struct Perl___notused_struct
+#endif
 
 #ifndef NVTYPE
 #  if defined(USE_LONG_DOUBLE) && defined(HAS_LONG_DOUBLE)


### PR DESCRIPTION
Perl v5.27.7 switched dNOOP to use an incomplete struct
declaration, regardless of the language.

This change is also going to update dNOOP on older versions.

Upstream-URL: https://github.com/Perl/perl5/commit/91ca80c3dda3ce14add7bd63f815556667be2fd4