### PR TITLE
change github clone URL from git:// to https://

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -106,7 +106,7 @@ sub configure
         },
         repository => {
           type => 'git',
-          url  => 'git://github.com/Dual-Life/Devel-PPPort.git',
+          url  => 'https://github.com/Dual-Life/Devel-PPPort.git',
           web  => 'https://github.com/Dual-Life/Devel-PPPort',
         },
       },


### PR DESCRIPTION
GitHub no longer supports the git:// protocol since it is unencrypted.