### PR TITLE
fix PERL_VERSION_xx comparison macros

### DIFF
--- a/parts/inc/version
+++ b/parts/inc/version
@@ -137,19 +137,60 @@ PERL_BCDVERSION
 /* N.B. These don't work if the patch number is 42 or 92, as those are what '*'
  * is in ASCII and EBCDIC respectively */
 __UNDEFINED__ PERL_VERSION_EQ(j,n,p)                                        \
-              (((p) == '*') ? (   (j) == D_PPP_VERSION_MAJOR                \
-                               && (n) == D_PPP_VERSION_MINOR)               \
+              (((p) == '*') ? (   (j) == D_PPP_MAJOR                        \
+                               && (n) == D_PPP_MINOR)                       \
                             : (PERL_BCDVERSION == D_PPP_JNP_TO_BCD(j,n,p)))
 __UNDEFINED__ PERL_VERSION_NE(j,n,p) (! PERL_VERSION_EQ(j,n,p))
 
 __UNDEFINED__ PERL_VERSION_LT(j,n,p)      /* p=='*' means _LT(j,n,0) */     \
-    (PERL_BCDVERSION < D_PPP_JNP_TO_BCD(                    (j),            \
+    (PERL_BCDVERSION < D_PPP_JNP_TO_BCD(                     (j),           \
                                                              (n),           \
                                          (((p) == '*') ? 0 : (p))))
 __UNDEFINED__ PERL_VERSION_GE(j,n,p) (! PERL_VERSION_LT(j,n,p))
 
-__UNDEFINED__ PERL_VERSION_LE(j,n,p)      /* p=='*' means _LT(j,n+1,0) */   \
-    (PERL_BCDVERSION < D_PPP_JNP_TO_BCD(                          (j),      \
-                                         (((p) == '*') ? ((n)+1) : (n)),    \
-                                         (((p) == '*') ?   0     : (p))))
+__UNDEFINED__ PERL_VERSION_LE(j,n,p)      /* p=='*' means _LE(j,n,999) */   \
+    (PERL_BCDVERSION <= D_PPP_JNP_TO_BCD(                      (j),         \
+                                                               (n),         \
+                                         (((p) == '*') ? 999 : (p))))
 __UNDEFINED__ PERL_VERSION_GT(j,n,p) (! PERL_VERSION_LE(j,n,p))
+
+=xsmisc
+
+/* PERL_VERSION_xx sanity checks */
+
+#if !PERL_VERSION_EQ(D_PPP_MAJOR, D_PPP_MINOR, D_PPP_PATCH)
+#  error PERL_VERSION_EQ(major, minor, patch) is false; expected true
+#endif
+#if !PERL_VERSION_EQ(D_PPP_MAJOR, D_PPP_MINOR, '*')
+#  error PERL_VERSION_EQ(major, minor, '*') is false; expected true
+#endif
+#if PERL_VERSION_NE(D_PPP_MAJOR, D_PPP_MINOR, D_PPP_PATCH)
+#  error PERL_VERSION_NE(major, minor, patch) is true; expected false
+#endif
+#if PERL_VERSION_NE(D_PPP_MAJOR, D_PPP_MINOR, '*')
+#  error PERL_VERSION_NE(major, minor, '*') is true; expected false
+#endif
+#if PERL_VERSION_LT(D_PPP_MAJOR, D_PPP_MINOR, D_PPP_PATCH)
+#  error PERL_VERSION_LT(major, minor, patch) is true; expected false
+#endif
+#if PERL_VERSION_LT(D_PPP_MAJOR, D_PPP_MINOR, '*')
+#  error PERL_VERSION_LT(major, minor, '*') is true; expected false
+#endif
+#if !PERL_VERSION_LE(D_PPP_MAJOR, D_PPP_MINOR, D_PPP_PATCH)
+#  error PERL_VERSION_LE(major, minor, patch) is false; expected true
+#endif
+#if !PERL_VERSION_LE(D_PPP_MAJOR, D_PPP_MINOR, '*')
+#  error PERL_VERSION_LE(major, minor, '*') is false; expected true
+#endif
+#if PERL_VERSION_GT(D_PPP_MAJOR, D_PPP_MINOR, D_PPP_PATCH)
+#  error PERL_VERSION_GT(major, minor, patch) is true; expected false
+#endif
+#if PERL_VERSION_GT(D_PPP_MAJOR, D_PPP_MINOR, '*')
+#  error PERL_VERSION_GT(major, minor, '*') is true; expected false
+#endif
+#if !PERL_VERSION_GE(D_PPP_MAJOR, D_PPP_MINOR, D_PPP_PATCH)
+#  error PERL_VERSION_GE(major, minor, patch) is false; expected true
+#endif
+#if !PERL_VERSION_GE(D_PPP_MAJOR, D_PPP_MINOR, '*')
+#  error PERL_VERSION_GE(major, minor, '*') is false; expected true
+#endif


### PR DESCRIPTION
- Fix `PERL_VERSION_EQ(x, y, '*')` and `PERL_VERSION_NE(x, y, '*')` by using the correct helper constants (`D_PPP_VERSION_MAJOR` and `D_PPP_VERSION_MINOR` don't exist)
- Fix PERL_VERSION_LE and PERL_VERSION_GT; these used to claim that for all versions X, X > X and !(X <= X). See <https://github.com/Perl/perl5/issues/21506>.
- Add unit tests.