### PR TITLE
fix string comparisons with $] to use numeric comparison instead (PR#63)

### DIFF
--- a/t/testutil.pl
+++ b/t/testutil.pl
@@ -29,7 +29,7 @@ my $noplan;
 # perls the burden of avoiding warnings becomes too large, and someone still
 # trying to use such outmoded versions should be willing to accept warnings in
 # our test suite.
-$SIG{__WARN__} = sub { die "Fatalized: $_[0]" } if $] ge "5.6.0";
+$SIG{__WARN__} = sub { die "Fatalized: $_[0]" } if "$]" >= 5.006;
 
 # This defines ASCII/UTF-8 vs EBCDIC/UTF-EBCDIC
 $::IS_ASCII  = ord 'A' ==  65;


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";

This ensures that the comparisons will still work when Perl's major version changes to anything greater than 9.

As it happens, this version check never worked properly anyway, because "5.041006" ge "5.6.0" is false when it is intended to be true. This may come as a surprise to some users of this utility, who have been ignoring warnings for a long time and now suddenly cannot.